### PR TITLE
Optmise trackChanged events

### DIFF
--- a/backend/src/lib/services/mopidy/index.spec.js
+++ b/backend/src/lib/services/mopidy/index.spec.js
@@ -21,6 +21,7 @@ describe('MopidyService', () => {
 
   it('handles call the global events', () => {
     MopidyService(wss, callbackMock)
+
     const instance = Mopidy.mock.instances[0]
     instance.playback = {
       getCurrentTrack: jest.fn()
@@ -31,6 +32,7 @@ describe('MopidyService', () => {
       getTracks: jest.fn()
         .mockImplementationOnce(() => Promise.resolve([{ uri: 'somemadeupuri' }]))
         .mockImplementationOnce(() => Promise.resolve([]))
+        .mockImplementationOnce(() => Promise.resolve('calledaftertracklistchanjged'))
     }
 
     expect(instance.on.mock.calls[0][0]).toEqual('websocket:error')
@@ -51,7 +53,10 @@ describe('MopidyService', () => {
     expect(instance.on.mock.calls[3][0]).toEqual('event:trackPlaybackStarted')
     expect(instance.on.mock.calls[4][0]).toEqual('event:playbackStateChanged')
     expect(instance.on.mock.calls[5][0]).toEqual('event:trackPlaybackResumed')
+
     expect(instance.on.mock.calls[6][0]).toEqual('event:tracklistChanged')
+    instance.on.mock.calls[6][1]()
+
     expect(instance.on.mock.calls[7][0]).toEqual('event:volumeChanged')
     instance.on.mock.calls[7][1]({ volume: '10' })
     expect(EventLogger.mock.calls[0]).toEqual([

--- a/frontend/src/constants/mopidy-api.js
+++ b/frontend/src/constants/mopidy-api.js
@@ -3,7 +3,6 @@ export default {
   EVENT_TRACK_PLAYBACK_STARTED: 'mopidy::event:trackPlaybackStarted',
   EVENT_PLAYBACK_STATE_CHANGED: 'mopidy::event:playbackStateChanged',
   EVENT_PLAYBACK_STATE_RESUMED: 'mopidy::event:trackPlaybackResumed',
-  EVENT_TRACKLIST_CHANGED: 'mopidy::event:tracklistChanged',
   TRACKLIST_GET_TRACKS: 'mopidy::tracklist.getTracks',
   TRACKLIST_ADD_TRACK: 'mopidy::tracklist.add',
   TRACKLIST_REMOVE_TRACK: 'mopidy::tracklist.remove',

--- a/frontend/src/utils/on-message-handler/index.js
+++ b/frontend/src/utils/on-message-handler/index.js
@@ -58,9 +58,6 @@ const onMessageHandler = (store, payload, progressTimer) => {
     case MopidyApi.PLAYBACK_GET_PLAYBACK_STATE:
       playBackChanged(store, data, progressTimer)
       break
-    case MopidyApi.EVENT_TRACKLIST_CHANGED:
-      store.dispatch(actions.getTrackList())
-      break
     case MopidyApi.TRACKLIST_GET_TRACKS:
       addTrackList(data, store)
       break

--- a/frontend/src/utils/on-message-handler/index.spec.js
+++ b/frontend/src/utils/on-message-handler/index.spec.js
@@ -129,18 +129,6 @@ describe('onMessageHandler', () => {
     })
   })
 
-  describe('EVENT_TRACKLIST_CHANGED', () => {
-    it('handles change', () => {
-      const newPayload = Object.assign(
-        payload,
-        { key: MopidyApi.EVENT_TRACKLIST_CHANGED }
-      )
-      spyOn(actions, 'getTrackList')
-      onMessageHandler(store, JSON.stringify(newPayload), progress)
-      expect(actions.getTrackList).toHaveBeenCalled()
-    })
-  })
-
   describe('TRACKLIST_GET_TRACKS', () => {
     it('handles change', () => {
       const newPayload = {


### PR DESCRIPTION
Currently any core `tracklistChanged` events get sent to the client and it's up to the client to re-ask for the updated.trackList. This PR optimises this by intercepting the `tracklistChanged` event in the API and fetching the updated tracklist and then passing it on to all the connected clients as a `getTracks` event which the clients can handle.