### PR TITLE
Post new Jukebox info to now playing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ WS_MOPIDY_URL=<Mopidy Host Name e.g mopidy-staging.local>
 WS_MOPIDY_PORT=6680
 CLIENT_ID=<dev google client id>
 CLIENT_ID_PRODUCTION=<production google client id>
+NOW_PLAYING_URL=<now playing add track endpoint>

--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,4 @@ WS_MOPIDY_URL=<Mopidy Host Name e.g mopidy-staging.local>
 WS_MOPIDY_PORT=6680
 CLIENT_ID=<dev google client id>
 CLIENT_ID_PRODUCTION=<production google client id>
-NOW_PLAYING_URL=<now playing add track endpoint>
+NOW_PLAYING_URL=<(OPTIONAL) now playing add track endpoint>

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ First, create a `.env` file in the root directory. Example vars can be found in 
 
 The backend also uses the Spotify API directly for some tasks. If you need this you will need to copy the `SPOTIFY_ID` and `SPOTIFY_SECRET` vars from the `.env.example` file to `.env` and [update the creds to your own](https://developer.spotify.com/dashboard/applications).
 
+In production we are posting currently playing track information to an endpoint defined by the `NOW_PLAYING_URL`, you can optionally set this in development (e.g. to test against [kyan.rocks](https://github.com/kyan/kyan-rocks). But you can also leave it blank.)
+
 ### Running the app
 
 From there, you can run everything in `Docker`. From the root of the repo, you just need to run:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ First, create a `.env` file in the root directory. Example vars can be found in 
 
 The backend also uses the Spotify API directly for some tasks. If you need this you will need to copy the `SPOTIFY_ID` and `SPOTIFY_SECRET` vars from the `.env.example` file to `.env` and [update the creds to your own](https://developer.spotify.com/dashboard/applications).
 
-In production we are posting currently playing track information to an endpoint defined by the `NOW_PLAYING_URL`, you can optionally set this in development (e.g. to test against [kyan.rocks](https://github.com/kyan/kyan-rocks). But you can also leave it blank.)
+In production, we are posting currently-playing track information to an endpoint defined by `NOW_PLAYING_URL`. You can optionally set this in development (e.g. to test against [kyan.rocks](https://github.com/kyan/kyan-rocks), but you can also leave it blank.
 
 ### Running the app
 

--- a/backend/src/lib/handlers/now-playing/index.js
+++ b/backend/src/lib/handlers/now-playing/index.js
@@ -1,0 +1,19 @@
+import HttpService from '../../services/http'
+
+const NowPlaying = {
+  addTrack: (track) => {
+    if (process.env.NOW_PLAYING_URL) {
+      HttpService.post({
+        url: `${process.env.NOW_PLAYING_URL}`,
+        data: {
+          title: track.name,
+          artist: track.artist.name,
+          album: track.album.name,
+          added_by: 'Jukebox JS'
+        }
+      })
+    }
+  }
+}
+
+export default NowPlaying

--- a/backend/src/lib/handlers/now-playing/index.spec.js
+++ b/backend/src/lib/handlers/now-playing/index.spec.js
@@ -1,0 +1,43 @@
+import NowPlaying from './index'
+import HttpService from '../../services/http'
+
+describe('NowPlaying', () => {
+  describe('addTrack', () => {
+    const httpMock = jest.fn()
+    const trackObject = {
+      name: 'Seasons (Waiting On You)',
+      artist: {
+        name: 'Future Islands'
+      },
+      album: {
+        name: 'Singles'
+      }
+    }
+    beforeAll(() => {
+      jest.spyOn(HttpService, 'post').mockImplementation(httpMock)
+    })
+    afterEach(() => {
+      jest.resetAllMocks();
+      delete process.env.NOW_PLAYING_URL;
+    })
+
+    it('when the NOW_PLAYING_URL is not set it calls to the HTTP service', () => {
+      process.env.NOW_PLAYING_URL = 'addthetrack.com'
+      NowPlaying.addTrack(trackObject)
+      expect(httpMock).toHaveBeenCalledWith({
+        url: 'addthetrack.com',
+        data: {
+          added_by: 'Jukebox JS',
+          title: 'Seasons (Waiting On You)',
+          artist: 'Future Islands',
+          album: 'Singles',
+        }
+      })
+    })
+
+   it('when the NOW_PLAYING_URL is not set it does nothing', () => {
+      NowPlaying.addTrack(trackObject)
+      expect(httpMock).not.toHaveBeenCalled();
+    })
+  })
+})

--- a/backend/src/lib/handlers/now-playing/index.spec.js
+++ b/backend/src/lib/handlers/now-playing/index.spec.js
@@ -6,22 +6,18 @@ describe('NowPlaying', () => {
     const httpMock = jest.fn()
     const trackObject = {
       name: 'Seasons (Waiting On You)',
-      artist: {
-        name: 'Future Islands'
-      },
-      album: {
-        name: 'Singles'
-      }
+      artist: { name: 'Future Islands' },
+      album: { name: 'Singles' }
     }
     beforeAll(() => {
       jest.spyOn(HttpService, 'post').mockImplementation(httpMock)
     })
     afterEach(() => {
-      jest.resetAllMocks();
-      delete process.env.NOW_PLAYING_URL;
+      jest.resetAllMocks()
+      delete process.env.NOW_PLAYING_URL
     })
 
-    it('when the NOW_PLAYING_URL is not set it calls to the HTTP service', () => {
+    it('when the NOW_PLAYING_URL is set it calls to the HTTP service', () => {
       process.env.NOW_PLAYING_URL = 'addthetrack.com'
       NowPlaying.addTrack(trackObject)
       expect(httpMock).toHaveBeenCalledWith({
@@ -30,14 +26,14 @@ describe('NowPlaying', () => {
           added_by: 'Jukebox JS',
           title: 'Seasons (Waiting On You)',
           artist: 'Future Islands',
-          album: 'Singles',
+          album: 'Singles'
         }
       })
     })
 
-   it('when the NOW_PLAYING_URL is not set it does nothing', () => {
+    it('when the NOW_PLAYING_URL is not set it does nothing', () => {
       NowPlaying.addTrack(trackObject)
-      expect(httpMock).not.toHaveBeenCalled();
+      expect(httpMock).not.toHaveBeenCalled()
     })
   })
 })

--- a/backend/src/lib/handlers/now-playing/index.spec.js
+++ b/backend/src/lib/handlers/now-playing/index.spec.js
@@ -4,10 +4,13 @@ import HttpService from '../../services/http'
 describe('NowPlaying', () => {
   describe('addTrack', () => {
     const httpMock = jest.fn()
+    const title = 'Seasons (Waiting On You)'
+    const artist = 'Future Islands'
+    const album = 'Singles'
     const trackObject = {
-      name: 'Seasons (Waiting On You)',
-      artist: { name: 'Future Islands' },
-      album: { name: 'Singles' }
+      name: title,
+      artist: { name: artist },
+      album: { name: album }
     }
     beforeAll(() => {
       jest.spyOn(HttpService, 'post').mockImplementation(httpMock)
@@ -24,9 +27,9 @@ describe('NowPlaying', () => {
         url: 'addthetrack.com',
         data: {
           added_by: 'Jukebox JS',
-          title: 'Seasons (Waiting On You)',
-          artist: 'Future Islands',
-          album: 'Singles'
+          title,
+          artist,
+          album
         }
       })
     })

--- a/backend/src/lib/services/http/index.js
+++ b/backend/src/lib/services/http/index.js
@@ -1,17 +1,17 @@
-import gaxios from 'gaxios'
+import { request } from 'gaxios'
 import logger from '../../../config/winston'
 
 const HttpService = {
-  post: async ({ url, data }) => {
-    try {
-      await gaxios.request({
-        url: url,
-        method: 'POST',
-        data
+  post: ({ url, data }) => {
+    request({
+      url: url,
+      method: 'POST',
+      data
+    })
+      .then(logger.info(`Posted to ${url}`, { message: JSON.stringify(data) }))
+      .catch(err => {
+        logger.error(`Something went wrong with ${url}`, { message: err.message })
       })
-    } catch (err) {
-      logger.error(`Something went wrong with ${url}`, { message: err.message })
-    }
   }
 }
 

--- a/backend/src/lib/services/http/index.js
+++ b/backend/src/lib/services/http/index.js
@@ -1,0 +1,20 @@
+import gaxios from 'gaxios'
+import logger from '../../../config/winston'
+
+const HttpService = {
+  post: async ({ url, data }) => {
+    try {
+      console.log('GET HERE')
+      await gaxios.request({
+        url: url,
+        method: 'POST',
+        data
+      })
+      console.log('AND HERE')
+    } catch (err) {
+      logger.error(`Something went wrong with ${url}`, { message: err.message })
+    }
+  }
+}
+
+export default HttpService

--- a/backend/src/lib/services/http/index.js
+++ b/backend/src/lib/services/http/index.js
@@ -4,13 +4,11 @@ import logger from '../../../config/winston'
 const HttpService = {
   post: async ({ url, data }) => {
     try {
-      console.log('GET HERE')
       await gaxios.request({
         url: url,
         method: 'POST',
         data
       })
-      console.log('AND HERE')
     } catch (err) {
       logger.error(`Something went wrong with ${url}`, { message: err.message })
     }

--- a/backend/src/lib/services/http/index.spec.js
+++ b/backend/src/lib/services/http/index.spec.js
@@ -13,6 +13,8 @@ jest.mock('gaxios', () => {
 describe('HttpService', () => {
   const errorLoggerMock = jest.fn()
   const infoLoggerMock = jest.fn()
+  const url = '/endpoint'
+  const data = { track: 'Good song' }
 
   beforeAll(() => {
     jest.spyOn(logger, 'info').mockImplementation(infoLoggerMock)
@@ -22,18 +24,16 @@ describe('HttpService', () => {
   describe('post', () => {
     beforeEach(() => {
       HttpService.post({
-        url: '/endpoint',
-        data: { track: 'Good song' }
+        url,
+        data
       })
     })
 
     it('should call through to the HTTP library with expected URL & data', () => {
       expect(request).toHaveBeenCalledWith({
         method: 'POST',
-        url: '/endpoint',
-        data: {
-          track: 'Good song'
-        }
+        url,
+        data
       })
       expect(infoLoggerMock).toHaveBeenCalledWith(
         'Posted to /endpoint',
@@ -44,10 +44,8 @@ describe('HttpService', () => {
     it('should catch an error and pass it to the logger', () => {
       expect(request).toHaveBeenCalledWith({
         method: 'POST',
-        url: '/endpoint',
-        data: {
-          track: 'Good song'
-        }
+        url,
+        data
       })
       expect(errorLoggerMock).toHaveBeenCalledWith(
         'Something went wrong with /endpoint',

--- a/backend/src/lib/services/http/index.spec.js
+++ b/backend/src/lib/services/http/index.spec.js
@@ -1,45 +1,58 @@
 import HttpService from './index'
-import gaxios from 'gaxios'
+import { request } from 'gaxios'
 import logger from '../../../config/winston'
-
+jest.mock('../../../config/winston')
 jest.mock('gaxios', () => {
   return {
     request: jest.fn()
       .mockImplementationOnce(() => Promise.resolve({ body: {} }))
-      .mockImplementationOnce(() => Promise.reject(new Error('bang')))
+      .mockImplementationOnce(() => Promise.reject(new Error('bang!')))
   }
 })
 
 describe('HttpService', () => {
-  // const errorLoggerMock = jest.fn()
-  // const requestMock = jest.fn()
+  const errorLoggerMock = jest.fn()
+  const infoLoggerMock = jest.fn()
 
-  // beforeAll(() => {
-  //   jest.spyOn(gaxios, 'request').mockImplementationOnce(requestMock)
-  //   jest.spyOn(logger, 'error').mockImplementation(errorLoggerMock)
-  // })
+  beforeAll(() => {
+    jest.spyOn(logger, 'info').mockImplementation(infoLoggerMock)
+    jest.spyOn(logger, 'error').mockImplementation(errorLoggerMock)
+  })
 
   describe('post', () => {
-    it('should call through to the HTTP library with expected URL & data', async () => {
-      await HttpService.post('/endpoint', { foo: 'bar' })
-      expect(gaxios.request).toHaveBeenCalledWith({
-        method: 'POST',
+    beforeEach(() => {
+      HttpService.post({
         url: '/endpoint',
-        data: {
-          foo: 'bar'
-        }
+        data: { track: 'Good song' }
       })
     })
 
-    it('should catch an error and pass it to the logger', async () => {
-      await HttpService.post('/this_one_breaks', { foo: 'bar' })
-      expect(gaxios.request).toHaveBeenCalledWith({
+    it('should call through to the HTTP library with expected URL & data', () => {
+      expect(request).toHaveBeenCalledWith({
         method: 'POST',
         url: '/endpoint',
         data: {
-          foo: 'bar'
+          track: 'Good song'
         }
       })
+      expect(infoLoggerMock).toHaveBeenCalledWith(
+        'Posted to /endpoint',
+        { message: JSON.stringify({ track: 'Good song' }) }
+      )
+    })
+
+    it('should catch an error and pass it to the logger', () => {
+      expect(request).toHaveBeenCalledWith({
+        method: 'POST',
+        url: '/endpoint',
+        data: {
+          track: 'Good song'
+        }
+      })
+      expect(errorLoggerMock).toHaveBeenCalledWith(
+        'Something went wrong with /endpoint',
+        { message: 'bang!' }
+      )
     })
   })
 })

--- a/backend/src/lib/services/http/index.spec.js
+++ b/backend/src/lib/services/http/index.spec.js
@@ -1,0 +1,45 @@
+import HttpService from './index'
+import gaxios from 'gaxios'
+import logger from '../../../config/winston'
+
+jest.mock('gaxios', () => {
+  return {
+    request: jest.fn()
+      .mockImplementationOnce(() => Promise.resolve({ body: {} }))
+      .mockImplementationOnce(() => Promise.reject(new Error('bang')))
+  }
+})
+
+describe('HttpService', () => {
+  // const errorLoggerMock = jest.fn()
+  // const requestMock = jest.fn()
+
+  // beforeAll(() => {
+  //   jest.spyOn(gaxios, 'request').mockImplementationOnce(requestMock)
+  //   jest.spyOn(logger, 'error').mockImplementation(errorLoggerMock)
+  // })
+
+  describe('post', () => {
+    it('should call through to the HTTP library with expected URL & data', async () => {
+      await HttpService.post('/endpoint', { foo: 'bar' })
+      expect(gaxios.request).toHaveBeenCalledWith({
+        method: 'POST',
+        url: '/endpoint',
+        data: {
+          foo: 'bar'
+        }
+      })
+    })
+
+    it('should catch an error and pass it to the logger', async () => {
+      await HttpService.post('/this_one_breaks', { foo: 'bar' })
+      expect(gaxios.request).toHaveBeenCalledWith({
+        method: 'POST',
+        url: '/endpoint',
+        data: {
+          foo: 'bar'
+        }
+      })
+    })
+  })
+})

--- a/backend/src/lib/transformer/index.spec.js
+++ b/backend/src/lib/transformer/index.spec.js
@@ -3,6 +3,8 @@ import TransformTrack from './transformers/mopidy/track'
 import TransformTracklist from './transformers/mopidy/tracklist'
 import settings from '../local-storage'
 import Spotify from '../services/spotify'
+import NowPlaying from '../handlers/now-playing'
+
 jest.mock('./transformers/mopidy/track', () => {
   return jest.fn(() => ({
     track: {
@@ -16,6 +18,7 @@ jest.mock('../services/mopidy/tracklist-trimmer')
 jest.mock('../services/spotify', () => ({
   canRecommend: jest.fn((_, fn) => fn('function'))
 }))
+jest.mock('../handlers/now-playing')
 jest.mock('./transformers/mopidy/tracklist')
 jest.useFakeTimers()
 
@@ -63,6 +66,10 @@ describe('Transformer', () => {
     it('does the right thing', () => {
       Transformer('mopidy::event:trackPlaybackStarted', data, mopidyMock)
       expect(TransformTrack).toHaveBeenCalledWith(data.tl_track.track)
+      expect(NowPlaying.addTrack).toHaveBeenCalledWith({
+        uri: 'spotify:track:40riOy7x9W7GXjyGp4pjAv',
+        length: 123456
+      })
       expect(settings.addToUniqueArray.mock.calls[0])
         .toEqual(['tracklist.last_played', 'spotify:track:40riOy7x9W7GXjyGp4pjAv', 10])
       expect(Spotify.canRecommend.mock.calls[0])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       - SPOTIFY_NEW_TRACKS_ADDED_LIMIT=3
       - LOCAL_STORAGE_PATH=./local-cache
       - CLIENT_ID=${CLIENT_ID}
+      - NOW_PLAYING_URL=${NOW_PLAYING_URL}
   mongodb:
     image: mongo:3.6.4
     container_name: mongodb


### PR DESCRIPTION
This PR solves issue #88 and sends a request to Kyan's 'now playing' from the new jukebox if the environment variable URL is set

It introduces a wrapper class for HTTP requests which is making use of https://github.com/googleapis/gaxios, already installed in the app. As we make more use of HTTP requests we can iterate on the messaging / handling.

**Note:** For now the user is hardcoded to 'Jukebox JS' with a view to solving this in #89 where we supply user information to the tracks