### PR TITLE
Use `new` when instantiating `mongoose.Schema`

### DIFF
--- a/backend/src/lib/services/mongodb/models/event/index.js
+++ b/backend/src/lib/services/mongodb/models/event/index.js
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose'
 
-const eventSchema = mongoose.Schema({
+const eventSchema = new mongoose.Schema({
   user: String,
   key: String,
   payload: mongoose.Schema.Types.Mixed

--- a/backend/src/lib/services/mongodb/models/image/index.js
+++ b/backend/src/lib/services/mongodb/models/image/index.js
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose'
 
-const imageSchema = mongoose.Schema({
+const imageSchema = new mongoose.Schema({
   uri: String,
   data: mongoose.Schema.Types.Mixed,
   expireAt: Date

--- a/backend/src/lib/services/mongodb/models/user/index.js
+++ b/backend/src/lib/services/mongodb/models/user/index.js
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose'
 
-const userSchema = mongoose.Schema({
+const userSchema = new mongoose.Schema({
   _id: String,
   fullname: String
 }, { _id: false })


### PR DESCRIPTION
The Mongoose docs indicate that the `new` keyword should be used when instantiating `mongoose.Schema`:

* https://mongoosejs.com/docs/index.html

```js
var kittySchema = new mongoose.Schema({
  name: String
});
```

* https://mongoosejs.com/docs/guide.html#definition

```js
var blogSchema = new Schema({
```

* https://mongoosejs.com/docs/guide.html#methods

```js
var animalSchema = new Schema({ name: String, type: String });
```