### PR TITLE
Fixes Google JWT token not being refreshed when tab hidden

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6472,6 +6472,30 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
+    "fast-unique-numbers": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-4.0.14.tgz",
+      "integrity": "sha512-AK5keT6/qW85wGN7WZQIeUZc5Z7PY/t1IQbuu4LVC0Y4zUA3eWLf6D8tZ55aamyI2HKBFTuyz1B+uwCigaWYvA==",
+      "requires": {
+        "@babel/runtime": "^7.7.4",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
+          "integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
     "faye-websocket": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
@@ -15963,6 +15987,82 @@
       "integrity": "sha512-P1WjMrUB3qgJNI9jfmpZ/htmBEjFh//6l/5y8SD9hg1Ef5zTTVVoRjTrTEzPrNBQvmhMxkoTsjOXN10GWU7aCg==",
       "requires": {
         "microevent.ts": "~0.1.1"
+      }
+    },
+    "worker-timers": {
+      "version": "5.0.35",
+      "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-5.0.35.tgz",
+      "integrity": "sha512-91ipoZIne7lClCXGhSJ0oSLQJqDBLyubByXgyJs2xfbaiuFKyRTGBF376I6y8aSUeGTfD8CcCGmWf2A+I0BgsA==",
+      "requires": {
+        "@babel/runtime": "^7.7.4",
+        "tslib": "^1.10.0",
+        "worker-timers-broker": "^5.0.30",
+        "worker-timers-worker": "^5.0.23"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
+          "integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
+    "worker-timers-broker": {
+      "version": "5.0.30",
+      "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-5.0.30.tgz",
+      "integrity": "sha512-qIA65etfSGxPgjFdga1PmoEnChB6HEG/foHREAMbdJHvOY72pLRvcGcZE6DJ1IsqzASSuCdCekVmvW53Cey60Q==",
+      "requires": {
+        "@babel/runtime": "^7.7.4",
+        "fast-unique-numbers": "^4.0.14",
+        "tslib": "^1.10.0",
+        "worker-timers-worker": "^5.0.23"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
+          "integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
+    "worker-timers-worker": {
+      "version": "5.0.23",
+      "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-5.0.23.tgz",
+      "integrity": "sha512-wGD99cjgExnfsV1/ZWxiIn0Ae4Lgcm/E3Our8SsSPt0RYMQX8ft1e/xwWy+m7IQlTxYB3mtpd7fU3ibngZqrXg==",
+      "requires": {
+        "@babel/runtime": "^7.7.4",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
+          "integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
       }
     },
     "wrap-ansi": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,8 @@
     "redux": "^4.0.4",
     "reselect": "^4.0.0",
     "semantic-ui-react": "^0.88.1",
-    "socket.io-client": "^2.2.0"
+    "socket.io-client": "^2.2.0",
+    "worker-timers": "^5.0.35"
   },
   "devDependencies": {
     "enzyme": "^3.9.0",

--- a/frontend/src/reducers/settings/index.js
+++ b/frontend/src/reducers/settings/index.js
@@ -7,6 +7,7 @@ const initalState = {
 const settings = (state = initalState, action) => {
   switch (action.type) {
     case Types.STORE_TOKEN:
+      if (action.token === state.token) return state
       return Object.assign({}, state, {
         token: action.token
       })

--- a/frontend/src/reducers/settings/index.spec.js
+++ b/frontend/src/reducers/settings/index.spec.js
@@ -17,6 +17,15 @@ describe('settings', () => {
     })
   })
 
+  it('handles STORE_TOKEN with same value', () => {
+    expect(reducer({ token: '1234' }, {
+      type: Types.STORE_TOKEN,
+      token: '1234'
+    })).toEqual({
+      token: '1234'
+    })
+  })
+
   it('handles CLEAR_STORE_TOKEN', () => {
     expect(reducer({ token: '1234' }, {
       type: Types.CLEAR_STORE_TOKEN

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -2,3 +2,22 @@ import { configure } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 
 configure({ adapter: new Adapter() })
+
+class Worker {
+  constructor (stringUrl) {
+    this.url = stringUrl
+    this.onmessage = () => { }
+    this.addEventListener = () => { }
+  }
+
+  postMessage (msg) {
+    this.onmessage(msg)
+  }
+}
+window.Worker = Worker
+
+function noOp () { }
+
+if (typeof window.URL.createObjectURL === 'undefined') {
+  Object.defineProperty(window.URL, 'createObjectURL', { value: noOp })
+}

--- a/frontend/src/utils/signin-token/index.js
+++ b/frontend/src/utils/signin-token/index.js
@@ -1,0 +1,16 @@
+import * as workerTimers from 'worker-timers'
+
+const checkForTokenInMilliseconds = 2700000
+
+const SignInToken = {
+  refresh: (googleApi, success) => {
+    return workerTimers.setTimeout(() => {
+      googleApi.reloadAuthResponse().then(
+        (response) => success(response.id_token),
+        (err) => console.warn('Token un-refreshable: ', err.message))
+    }, checkForTokenInMilliseconds)
+  },
+  clear: (id) => { if (id) workerTimers.clearTimeout(id) }
+}
+
+export default SignInToken

--- a/frontend/src/utils/signin-token/index.spec.js
+++ b/frontend/src/utils/signin-token/index.spec.js
@@ -1,0 +1,76 @@
+import * as workerTimers from 'worker-timers'
+import SignInToken from './index'
+
+jest.mock('worker-timers', () => {
+  return {
+    setTimeout: jest.fn((func, _) => {
+      func()
+      return 'newtoken'
+    }),
+    clearTimeout: jest.fn()
+  }
+})
+
+describe('SignInToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('.refresh', () => {
+    it('returns a token', done => {
+      expect.assertions(2)
+      const mockGoogle = {
+        reloadAuthResponse: jest.fn()
+          .mockImplementation(() => Promise.resolve({ id_token: 'new_token' }))
+      }
+      const mockSuccess = jest.fn()
+      spyOn(console, 'warn')
+
+      SignInToken.refresh(mockGoogle, mockSuccess)
+
+      setTimeout(() => {
+        try {
+          expect(mockSuccess).toHaveBeenCalledWith('new_token')
+          expect(console.warn).not.toHaveBeenCalled()
+          done()
+        } catch (err) {
+          done.fail(err)
+        }
+      })
+    })
+
+    it('errors to the console', done => {
+      expect.assertions(2)
+      const mockGoogle = {
+        reloadAuthResponse: jest.fn()
+          .mockImplementation(() => Promise.reject(new Error('bang')))
+      }
+      const mockSuccess = jest.fn()
+      spyOn(console, 'warn')
+
+      SignInToken.refresh(mockGoogle, mockSuccess)
+
+      setTimeout(() => {
+        try {
+          expect(console.warn).toHaveBeenCalledWith('Token un-refreshable: ', 'bang')
+          expect(mockSuccess).not.toHaveBeenCalled()
+          done()
+        } catch (err) {
+          done.fail(err)
+        }
+      })
+    })
+  })
+
+  describe('.clear', () => {
+    it('clears a token when passed an ID', () => {
+      SignInToken.clear(123)
+      expect(workerTimers.clearTimeout).toHaveBeenCalledWith(123)
+    })
+
+    it('does not clear a token when passed no ID', () => {
+      SignInToken.clear()
+      expect(workerTimers.clearTimeout).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
When the user signs via google a token is send back. This is a short lived token (60 mins). We use this token to authenticate requests to the API. The Google JS lib handles refreshing the token so it never expires but they use `setTimeout` to do this. When a browser tab is not in focus the browser suspends timeouts (so they don't use unnecessary resource). This means you have a situation where the token would not get updated and the user would have to wait for a failure before having to refresh their page. Not a great UX.

This PR adds our own refresh using background workers. Background workers don't suffer the same suspend issue. When we get a new token we add a background timer for 45 mins and then refresh the token then.

Fixes #93

