### PR TITLE
Adds base docker setup for local mopidy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 SPOTIFY_ID=<Add ID here>
 SPOTIFY_SECRET=<Add secret here>
-WS_MOPIDY_URL=<Mopidy Host Name e.g mopidy-staging.local>
+WS_MOPIDY_URL=<Mopidy Host Name e.g mopidy.local>
 WS_MOPIDY_PORT=6680
 CLIENT_ID=<dev google client id>
 CLIENT_ID_PRODUCTION=<production google client id>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,15 @@ In production, we are posting currently-playing track information to an endpoint
 From there, you can run everything in `Docker`. From the root of the repo, you just need to run:
 
 ```
-$ docker-compose up
+$ make build
+$ make serve
+```
+
+Or to run with local Mopidy:
+
+```
+$ make build-all
+$ make serve-all
 ```
 
 This will give you a working client and API plus the persistence layer. The client is available at http://localhost:3001 running in dev mode, meaning any changes will cause the server to restart.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ cd jukebox-js
 
 First, create a `.env` file in the root directory. Example vars can be found in the [`.env.example`](.env.example) file. At a minimum `WS_MOPIDY_URL`, `WS_MOPIDY_PORT` and `CLIENT_ID` values need to be defined.
 
-`WS_MOPIDY_URL` must point to an instance of Mopidy, for example [running locally on a Raspberry Pi](docs/mopidy_install.md).
+`WS_MOPIDY_URL` must point to an instance of Mopidy, for example [running locally on a Raspberry Pi](docs/mopidy_install.md), [or within Docker](docs/mopidy_docker.md).
 
 `CLIENT_ID` must be set to a valid Google app ID in order for any interaction with the app to be possible.
 
@@ -47,6 +47,8 @@ This will give you a working client and API plus the persistence layer. The clie
 ### Mopidy
 
 If you want to run your own copy of Mopidy, you can buy yourself a Raspberry Pi and follow [these instructions](docs/mopidy_install.md).
+
+Alternatively, it is possible to run Mopidy from [within Docker](docs/mopidy_docker.md), although this currently does not support audio playback.
 
 ### Specs
 

--- a/docker-compose-mopidy.yml
+++ b/docker-compose-mopidy.yml
@@ -1,0 +1,17 @@
+version: '3.7'
+
+services:
+  mopidy:
+    container_name: mopidy
+    build:
+      context: ./mopidy
+    volumes:
+      - ./mopidy/config/mopidy.conf:/config/mopidy.conf
+    command: mopidy
+    ports:
+      - "6600:6600"
+      - "6680:6680"
+    networks:
+      default:
+        aliases:
+          - mopidy.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-version: '3.4'
+version: '3.7'
+
 services:
   jukebox-client:
     container_name: jukebox-client
@@ -34,6 +35,7 @@ services:
       - "9229:9229"
     depends_on:
       - mongodb
+      - mopidy
     environment:
       - NODE_ENV=development
       - PORT=8080
@@ -57,3 +59,17 @@ services:
       - ./data/db:/data/db
     ports:
       - 27017:27017
+  mopidy:
+    container_name: mopidy
+    build:
+      context: ./mopidy
+    volumes:
+      - ./mopidy/config/mopidy.conf:/config/mopidy.conf
+    command: mopidy
+    ports:
+      - "6600:6600"
+      - "6680:6680"
+    networks:
+      default:
+        aliases:
+          - mopidy.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
       - "9229:9229"
     depends_on:
       - mongodb
-      - mopidy
     environment:
       - NODE_ENV=development
       - PORT=8080
@@ -59,17 +58,3 @@ services:
       - ./data/db:/data/db
     ports:
       - 27017:27017
-  mopidy:
-    container_name: mopidy
-    build:
-      context: ./mopidy
-    volumes:
-      - ./mopidy/config/mopidy.conf:/config/mopidy.conf
-    command: mopidy
-    ports:
-      - "6600:6600"
-      - "6680:6680"
-    networks:
-      default:
-        aliases:
-          - mopidy.local

--- a/docs/mopidy_docker.md
+++ b/docs/mopidy_docker.md
@@ -11,6 +11,8 @@ You will need to provide valid credentials for Spotify within the [mopidy.conf](
 
 Alongside Mopidy, this also runs the [Iris](https://github.com/jaedb/Iris) front-end, accessible at http://localhost:6680/iris - which can be used to browse for and add tracks to the playlist.
 
+Credit to [Werner Beroux](https://github.com/wernight/docker-mopidy) for authoring the original Mopidy Dockerfile upon with this version is based.
+
 ### Note
 
 Audio playback is currently not supported when running Mopidy from within Docker, although this should hopefully be possible eventually (some of the PulseAudio config is already in place).

--- a/docs/mopidy_docker.md
+++ b/docs/mopidy_docker.md
@@ -1,0 +1,14 @@
+## Mopidy within Docker
+
+As an alternative to [using a Raspberry Pi](docs/mopidy_install.md), Mopidy can be run locally using Docker by running the commands:
+
+```
+$ make build-all
+$ make serve-all
+```
+
+Alongside Mopidy, this also runs the [Iris](https://github.com/jaedb/Iris) front-end, accessible at http://localhost:6680/iris - which can be used to browse for and add tracks to the playlist.
+
+### Note
+
+Audio playback is currently not supported when running Mopidy from within Docker, although this should hopefully be possible eventually (some of the PulseAudio config is already in place).

--- a/docs/mopidy_docker.md
+++ b/docs/mopidy_docker.md
@@ -7,6 +7,8 @@ $ make build-all
 $ make serve-all
 ```
 
+You will need to provide valid credentials for Spotify within the [mopidy.conf](mopidy/config/mopidy.conf) file.
+
 Alongside Mopidy, this also runs the [Iris](https://github.com/jaedb/Iris) front-end, accessible at http://localhost:6680/iris - which can be used to browse for and add tracks to the playlist.
 
 ### Note

--- a/makefile
+++ b/makefile
@@ -1,0 +1,28 @@
+help:
+	@echo "How to use:"
+	@echo
+	@echo "  $$ make build					builds images excluding local mopidy"
+	@echo "  $$ make build-all			builds images including local mopidy"
+	@echo "  $$ make serve    			start the local development environment excluding local mopidy"
+	@echo "  $$ make serve-all    	start the local development environment including local mopidy"
+	@echo "  $$ make test-frontend  runs client specs"
+	@echo "  $$ make test-backend  	runs api specs"
+
+build:
+	docker-compose down
+	docker-compose build
+
+build-all:
+	docker-compose -f docker-compose.yml -f docker-compose-mopidy.yml build
+
+serve:
+	docker-compose up
+
+serve-all:
+	docker-compose -f docker-compose.yml -f docker-compose-mopidy.yml up
+
+test-frontend:
+	./scripts/specs-client.sh
+
+test-backend:
+	./scripts/specs-api.sh

--- a/mopidy/Dockerfile
+++ b/mopidy/Dockerfile
@@ -40,7 +40,7 @@ COPY ./entrypoint.sh /entrypoint.sh
 # Default configuration.
 COPY ./config/mopidy.conf /config/mopidy.conf
 
-# Copy the pulse-client configuratrion.
+# Copy the pulse-client configuration.
 COPY ./config/pulse-client.conf /etc/pulse/client.conf
 
 EXPOSE 6600 6680 5555/udp

--- a/mopidy/Dockerfile
+++ b/mopidy/Dockerfile
@@ -1,0 +1,49 @@
+FROM debian:stretch-slim
+
+RUN set -ex \
+    # Official Mopidy install for Debian/Ubuntu along with some extensions
+    # (see https://docs.mopidy.com/en/latest/installation/debian/ )
+ && apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        curl \
+        dumb-init \
+        gcc \
+        gnupg \
+        gstreamer1.0-alsa \
+        gstreamer1.0-plugins-bad \
+        python-crypto \
+        python-pykka \
+ && curl -L https://apt.mopidy.com/mopidy.gpg | apt-key add - \
+ && curl -L https://apt.mopidy.com/mopidy.list -o /etc/apt/sources.list.d/mopidy.list \
+ && apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        mopidy \
+        mopidy-spotify \
+ && curl -L https://bootstrap.pypa.io/get-pip.py | python - \
+ && pip install -U six pyasn1 requests[security] cryptography \
+ && pip install \
+        Mopidy-Iris \
+        pyopenssl \
+    # Clean-up
+ && apt-get purge --auto-remove -y \
+        curl \
+        gcc \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.cache
+
+RUN  mkdir -p /root/.config \
+ && ln -s /config /root/.config/mopidy
+
+# Start helper script.
+COPY ./entrypoint.sh /entrypoint.sh
+
+# Default configuration.
+COPY ./config/mopidy.conf /config/mopidy.conf
+
+# Copy the pulse-client configuratrion.
+COPY ./config/pulse-client.conf /etc/pulse/client.conf
+
+EXPOSE 6600 6680 5555/udp
+
+ENTRYPOINT ["/usr/bin/dumb-init", "/entrypoint.sh"]
+CMD ["/usr/bin/mopidy"]

--- a/mopidy/Dockerfile
+++ b/mopidy/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 RUN set -ex \
     # Official Mopidy install for Debian/Ubuntu along with some extensions

--- a/mopidy/config/mopidy.conf
+++ b/mopidy/config/mopidy.conf
@@ -4,8 +4,6 @@ config_dir = /etc/mopidy
 data_dir = /var/lib/mopidy
 
 [audio]
-# Only needed if running Icecast2
-# output = tee name=t ! queue ! audioresample ! autoaudiosink t. ! queue ! lamemp3enc ! shout2send mount=radio ip=127.0.0.1 port=8000 password=hackme
 mixer_volume = 40
 
 [logging]

--- a/mopidy/config/mopidy.conf
+++ b/mopidy/config/mopidy.conf
@@ -1,0 +1,50 @@
+[core]
+cache_dir = /var/cache/mopidy
+config_dir = /etc/mopidy
+data_dir = /var/lib/mopidy
+
+[audio]
+# Only needed if running Icecast2
+# output = tee name=t ! queue ! audioresample ! autoaudiosink t. ! queue ! lamemp3enc ! shout2send mount=radio ip=127.0.0.1 port=8000 password=hackme
+mixer_volume = 40
+
+[logging]
+config_file = /etc/mopidy/logging.conf
+debug_file = /var/log/mopidy/mopidy-debug.log
+
+[local]
+enabled = false
+#media_dir = /var/lib/mopidy/media
+
+[m3u]
+#playlists_dir = /var/lib/mopidy/playlists
+
+[file]
+enabled = false
+
+[http]
+enabled = true
+hostname = 0.0.0.0
+port = 6680
+static_dir =
+
+[spotify]
+enabled = true
+username = xxx
+password = xxx
+client_id = xxx
+client_secret = xxx
+private_session = true
+
+[mpd]
+enabled = true
+hostname = 0.0.0.0
+port = 6600
+#password =
+max_connections = 20
+connection_timeout = 60
+zeroconf = Mopidy MPD server on $hostname
+command_blacklist =
+  listall
+  listallinfo
+default_playlist_scheme = m3u

--- a/mopidy/config/pulse-client.conf
+++ b/mopidy/config/pulse-client.conf
@@ -1,0 +1,9 @@
+# Connect to the host's server using the mounted UNIX socket
+default-server = unix:/run/user/105/pulse/native
+
+# Prevent a server running in the container
+autospawn = no
+daemon-binary = /bin/true
+
+# Prevent the use of shared memory
+enable-shm = false

--- a/mopidy/entrypoint.sh
+++ b/mopidy/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ -z "$PULSE_COOKIE_DATA" ]
+then
+    echo -ne $(echo $PULSE_COOKIE_DATA | sed -e 's/../\\x&/g') >$HOME/pulse.cookie
+    export PULSE_COOKIE=$HOME/pulse.cookie
+fi
+
+exec "$@"


### PR DESCRIPTION
First pass at satisfying issue #101 

If someone other than me could also pull this down to validate that it works correctly that would be great. Don't remove the "Do not merge" label until at least one other person has checked.

TODO:

- [x] Remove mopidy dependency in docker-compose - dockerised mopidy should be optional at this point.
- [x] Add documentation around process
- [x] Secondary confirmation that. It. Works.