### PR TITLE
Use .env for mopidy config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@ WS_MOPIDY_PORT=6680
 CLIENT_ID=<dev google client id>
 CLIENT_ID_PRODUCTION=<production google client id>
 NOW_PLAYING_URL=<(OPTIONAL) now playing add track endpoint>
+MOPIDY_USERNAME=<SPOTIFY username for Mopidy>
+MOPIDY_PASSWORD=<SPOTIFY password for Mopidy>
+MOPIDY_CLIENT_ID=<SPOTIFY client id for Mopidy>
+MOPIDY_CLIENT_SECRET=<SPOTIFY client secret for Mopidy>

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log
 data
+mopidy-data

--- a/docker-compose-mopidy.yml
+++ b/docker-compose-mopidy.yml
@@ -9,10 +9,6 @@ services:
     ports:
       - "6600:6600"
       - "6680:6680"
-    networks:
-      default:
-        aliases:
-          - mopidy
     volumes:
       - ./mopidy-data:/var/lib/mopidy
     environment:

--- a/docker-compose-mopidy.yml
+++ b/docker-compose-mopidy.yml
@@ -13,6 +13,8 @@ services:
       default:
         aliases:
           - mopidy
+    volumes:
+      - ./mopidy-data:/var/lib/mopidy
     environment:
       - MOPIDY_USERNAME=${MOPIDY_USERNAME}
       - MOPIDY_PASSWORD=${MOPIDY_PASSWORD}

--- a/docker-compose-mopidy.yml
+++ b/docker-compose-mopidy.yml
@@ -5,8 +5,6 @@ services:
     container_name: mopidy
     build:
       context: ./mopidy
-    volumes:
-      - ./mopidy/config/mopidy.conf:/config/mopidy.conf
     command: mopidy
     ports:
       - "6600:6600"
@@ -14,4 +12,9 @@ services:
     networks:
       default:
         aliases:
-          - mopidy.local
+          - mopidy
+    environment:
+      - MOPIDY_USERNAME=${MOPIDY_USERNAME}
+      - MOPIDY_PASSWORD=${MOPIDY_PASSWORD}
+      - MOPIDY_CLIENT_ID=${MOPIDY_CLIENT_ID}
+      - MOPIDY_CLIENT_SECRET=${MOPIDY_CLIENT_SECRET}

--- a/docs/mopidy_docker.md
+++ b/docs/mopidy_docker.md
@@ -7,7 +7,7 @@ $ make build-all
 $ make serve-all
 ```
 
-You will need to provide valid credentials for Spotify within the [mopidy.conf](mopidy/config/mopidy.conf) file.
+You will need to enter [valid credentials for Spotify](https://mopidy.com/authenticate/) to the [.env](../README.md#Environment) file. These will then be copied to the container when you start it up.
 
 Alongside Mopidy, this also runs the [Iris](https://github.com/jaedb/Iris) front-end, accessible at http://localhost:6680/iris - which can be used to browse for and add tracks to the playlist.
 

--- a/makefile
+++ b/makefile
@@ -1,12 +1,12 @@
 help:
 	@echo "How to use:"
 	@echo
-	@echo "  $$ make build					builds images excluding local mopidy"
-	@echo "  $$ make build-all			builds images including local mopidy"
-	@echo "  $$ make serve    			start the local development environment excluding local mopidy"
-	@echo "  $$ make serve-all    	start the local development environment including local mopidy"
-	@echo "  $$ make test-frontend  runs client specs"
-	@echo "  $$ make test-backend  	runs api specs"
+	@echo "  $$ make build            builds images excluding local mopidy"
+	@echo "  $$ make build-all        builds images including local mopidy"
+	@echo "  $$ make serve            start the local development environment excluding local mopidy"
+	@echo "  $$ make serve-all        start the local development environment including local mopidy"
+	@echo "  $$ make test-frontend    runs client specs"
+	@echo "  $$ make test-backend     runs api specs"
 
 build:
 	docker-compose down

--- a/mopidy/config/mopidy.conf
+++ b/mopidy/config/mopidy.conf
@@ -28,10 +28,10 @@ static_dir =
 
 [spotify]
 enabled = true
-username = xxx
-password = xxx
-client_id = xxx
-client_secret = xxx
+username = %MOPIDY_USERNAME%
+password = %MOPIDY_PASSWORD%
+client_id = %MOPIDY_CLIENT_ID%
+client_secret = %MOPIDY_CLIENT_SECRET%
 private_session = true
 
 [mpd]

--- a/mopidy/config/mopidy.conf
+++ b/mopidy/config/mopidy.conf
@@ -2,6 +2,8 @@
 cache_dir = /var/cache/mopidy
 config_dir = /etc/mopidy
 data_dir = /var/lib/mopidy
+max_tracklist_length = 200
+restore_state = true
 
 [audio]
 mixer_volume = 40

--- a/mopidy/entrypoint.sh
+++ b/mopidy/entrypoint.sh
@@ -6,4 +6,9 @@ then
     export PULSE_COOKIE=$HOME/pulse.cookie
 fi
 
+MOPIDY_CONF='/config/mopidy.conf'
+if [[ -f "$MOPIDY_CONF" ]]; then
+  sed -i "s~%MOPIDY_USERNAME%~$MOPIDY_USERNAME~g; s~%MOPIDY_PASSWORD%~$MOPIDY_PASSWORD~g; s~%MOPIDY_CLIENT_ID%~$MOPIDY_CLIENT_ID~g; s~%MOPIDY_CLIENT_SECRET%~$MOPIDY_CLIENT_SECRET~g" $MOPIDY_CONF
+fi
+
 exec "$@"


### PR DESCRIPTION
This lets users use their `.env` for the mopidy config variables. Means they can set:
```
MOPIDY_USERNAME=<SPOTIFY username for Mopidy>
MOPIDY_PASSWORD=<SPOTIFY password for Mopidy>
MOPIDY_CLIENT_ID=<SPOTIFY client id for Mopidy>
MOPIDY_CLIENT_SECRET=<SPOTIFY client secret for Mopidy>
```
in their `.env` and it will be copied to the container when it starts up. I needed to remove the volume mount to do this. I think it's only these variable that a user it likely to need to change at the mo.

I've also changed `mopidy.local` to `mopidy` to potentially save any issues in the office with the `.local` domain. I had problems using this domain at home for some reason.

I've also added persistence so you can carry on where you left off.