### PR TITLE
Bit of refactoring replacing some callbacks with Promises and some other bits and pieces

### DIFF
--- a/backend/src/constants/mopidy.js
+++ b/backend/src/constants/mopidy.js
@@ -19,6 +19,7 @@ export default {
   TRACKLIST_ADD: 'mopidy::tracklist.add',
   TRACKLIST_CLEAR: 'mopidy::tracklist.clear',
   TRACKLIST_REMOVE: 'mopidy::tracklist.remove',
+  VALIDATION_ERROR: 'mopidy::tracklist.validation',
   AUTHORISED_KEYS: [
     'mopidy::tracklist.add',
     'mopidy::tracklist.remove',

--- a/backend/src/handlers/mopidy/image-cache/index.js
+++ b/backend/src/handlers/mopidy/image-cache/index.js
@@ -2,9 +2,8 @@ import logger from 'config/winston'
 import Image from 'services/mongodb/models/image'
 import MopidyConsts from 'constants/mopidy'
 
-const isImageKey = (key) => {
-  return (key === MopidyConsts.LIBRARY_GET_IMAGES)
-}
+const isImageKey = key => key === MopidyConsts.LIBRARY_GET_IMAGES
+const fetchFromCache = key => Image.findOne({ 'uri': key })
 
 const expiresDate = (imgs) => {
   const hour = 3600 * 1000
@@ -18,37 +17,29 @@ const addToCacheHandler = (encodedKey) => {
   const handler = (data) => {
     const uri = encodedKey.split('#')[1]
 
-    Image
-      .create({
-        expireAt: expiresDate(data[uri]),
-        uri: encodedKey,
-        data
-      })
-
-    return uri
+    return Image.create({
+      expireAt: expiresDate(data[uri]),
+      uri: encodedKey,
+      data
+    })
   }
   return handler
 }
 
-const fetchFromCache = (key, responseHandler) => {
-  return Image.findOne({ 'uri': key })
-    .then(resp => responseHandler(resp))
-}
-
 const ImageCache = {
-  check: (key, data, fn) => {
-    if (!isImageKey(key)) return fn(null, { image: false })
+  check: (key, data) => new Promise((resolve) => {
+    if (!isImageKey(key)) return resolve({ image: false })
     const encodedKey = `${key}#${data[0][0]}`
 
-    fetchFromCache(encodedKey, (respo) => {
-      if (respo) {
+    fetchFromCache(encodedKey).then((response) => {
+      if (response) {
         logger.info('Using cache', { key: encodedKey })
-        return fn(null, { image: respo.data })
+        return resolve({ image: response.data })
       } else {
-        return fn(null, { addToCache: addToCacheHandler(encodedKey) })
+        return resolve({ addToCache: addToCacheHandler(encodedKey) })
       }
     })
-  }
+  })
 }
 
 export default ImageCache

--- a/backend/src/services/spotify/index.js
+++ b/backend/src/services/spotify/index.js
@@ -114,13 +114,22 @@ const SpotifyService = {
     })
   },
 
-  validateTrack: (uri, callback) => {
+  validateTrack: (uri) => {
     const tracklist = settings.getItem(SettingsConsts.TRACKLIST_CURRENT)
-    if (tracklist.includes(uri)) return
 
-    getTrack(uri, (track) => {
-      if (track.explicit) return
-      callback()
+    return new Promise((resolve, reject) => {
+      if (tracklist.includes(uri)) {
+        const message = `Already in tracklist: ${uri}`
+        return reject(new Error(message))
+      }
+
+      getTrack(uri, (track) => {
+        if (track.explicit) {
+          const message = `Is there a radio mix? - ${track.name}`
+          return reject(new Error(message))
+        }
+        return resolve(true)
+      })
     })
   }
 }

--- a/backend/src/utils/broadcaster/index.spec.js
+++ b/backend/src/utils/broadcaster/index.spec.js
@@ -28,7 +28,8 @@ describe('Broadcaster', () => {
         .toEqual('{"key":"mopidy::playback.next","data":"hello mum"}')
       expect(EventLogger.mock.calls[0][0]).toEqual({ encoded_key: 'mopidy::playback.next' })
       expect(EventLogger.mock.calls[0][1]).toBeNull()
-      expect(EventLogger.mock.calls[0][2]).toEqual('hello mum')
+      expect(EventLogger.mock.calls[0][2])
+        .toEqual('{"key":"mopidy::playback.next","data":"hello mum"}')
       expect(EventLogger.mock.calls[0][3]).toEqual('OUTGOING API')
     })
 
@@ -48,13 +49,14 @@ describe('Broadcaster', () => {
       expect(sendMock.mock.calls.length).toEqual(1)
       expect(sendMock.mock.calls[0][0]).toEqual('message')
       expect(sendMock.mock.calls[0][1])
-        .toEqual('{"key":"mopidy::playback.next","data":"hello mum"}')
+        .toEqual('{"key":"mopidy::playback.next","data":"hello mum","user":{"_id":"123"}}')
       expect(EventLogger.mock.calls[0][0]).toEqual({
         encoded_key: 'mopidy::playback.next',
         user: { _id: '123' }
       })
       expect(EventLogger.mock.calls[0][1]).toBeNull()
-      expect(EventLogger.mock.calls[0][2]).toEqual('hello mum')
+      expect(EventLogger.mock.calls[0][2])
+        .toEqual('{"key":"mopidy::playback.next","data":"hello mum","user":{"_id":"123"}}')
       expect(EventLogger.mock.calls[0][3]).toEqual('OUTGOING API [AUTHED]')
     })
 
@@ -71,7 +73,8 @@ describe('Broadcaster', () => {
       const message = 'hello mum'
 
       broadcaster.to(clientMock, payload, message)
-      expect(sendMock.mock.calls[0]).toEqual(['message', '{"key":"mopidy::playback.next","data":"hello mum"}'])
+      expect(sendMock.mock.calls[0])
+        .toEqual(['message', '{"key":"mopidy::playback.next","data":"hello mum","user":{"_id":"123"}}'])
       expect(logger.error.mock.calls[0][0]).toEqual('Broadcaster#to')
       expect(logger.error.mock.calls[0][1]).toEqual({ message: 'oops' })
     })
@@ -90,7 +93,7 @@ describe('Broadcaster', () => {
       expect(sendMock.mock.calls.length).toEqual(1)
       expect(sendMock.mock.calls[0][0]).toEqual('message')
       expect(sendMock.mock.calls[0][1]).toEqual('{"key":"mopidy::playback.next","data":"hello mum"}')
-      expect(EventLogger.mock.calls[0][0]).toEqual('{"key":"mopidy::playback.next","data":"hello mum"}')
+      expect(EventLogger.mock.calls[0][0]).toEqual('mopidy::playback.next')
       expect(EventLogger.mock.calls[0][1]).toBeNull()
       expect(EventLogger.mock.calls[0][2]).toEqual('hello mum')
       expect(EventLogger.mock.calls[0][3]).toEqual('OUTGOING API BROADCAST')

--- a/backend/src/utils/payload/index.js
+++ b/backend/src/utils/payload/index.js
@@ -3,10 +3,11 @@ import ErrorHandler from 'handlers/errors'
 const Payload = {
   toJsonString: (data) => JSON.stringify(data),
 
-  encode: (key, data) => {
+  encode: (key, data, user) => {
     return {
       key,
-      data
+      data,
+      user
     }
   },
 
@@ -35,8 +36,8 @@ const Payload = {
     }
   },
 
-  encodeToJson: (key, data) => {
-    return Payload.toJsonString(Payload.encode(key, data))
+  encodeToJson: (key, data, user) => {
+    return Payload.toJsonString(Payload.encode(key, data, user))
   }
 }
 

--- a/backend/src/utils/transformer/index.js
+++ b/backend/src/utils/transformer/index.js
@@ -69,6 +69,7 @@ const Transform = {
       case Mopidy.MIXER_SET_VOLUME:
       case Mopidy.PLAYBACK_GET_TIME_POSITION:
       case Mopidy.PLAYBACK_GET_STATE:
+      case Mopidy.VALIDATION_ERROR:
       case Auth.AUTHENTICATION_TOKEN_INVALID:
         return data
       default:

--- a/frontend/src/constants/mopidy-api.js
+++ b/frontend/src/constants/mopidy-api.js
@@ -20,5 +20,6 @@ export default {
   STOPPED: 'stopped',
   SET_VOLUME: 'mopidy::mixer.setVolume',
   GET_VOLUME: 'mopidy::mixer.getVolume',
-  EVENT_VOLUME_CHANGED: 'mopidy::event:volumeChanged'
+  EVENT_VOLUME_CHANGED: 'mopidy::event:volumeChanged',
+  VALIDATION_ERROR: 'mopidy::tracklist.validation'
 }

--- a/frontend/src/utils/notify/__snapshots__/index.spec.js.snap
+++ b/frontend/src/utils/notify/__snapshots__/index.spec.js.snap
@@ -1,9 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`notify calls the toast interface 1`] = `
+exports[`notify calls the success toast interface 1`] = `
 Array [
-  "Added Foo by Bar",
+  "A message",
   "success",
+  3000,
+  Object {},
+]
+`;
+
+exports[`notify calls the warning toast interface 1`] = `
+Array [
+  "A message",
+  "warning",
   3000,
   Object {},
 ]

--- a/frontend/src/utils/notify/index.js
+++ b/frontend/src/utils/notify/index.js
@@ -1,5 +1,8 @@
 import { notify } from 'react-notify-toast'
 
-const Notify = (message) => notify.show(message, 'success', 3000, {})
+const Notify = {
+  success: (message) => notify.show(message, 'success', 3000, {}),
+  warning: (message) => notify.show(message, 'warning', 3000, {})
+}
 
 export default Notify

--- a/frontend/src/utils/notify/index.spec.js
+++ b/frontend/src/utils/notify/index.spec.js
@@ -3,8 +3,18 @@ import NotifyMe from './index'
 jest.mock('react-notify-toast')
 
 describe('notify', () => {
-  it('calls the toast interface', () => {
-    NotifyMe('Added Foo by Bar')
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('calls the success toast interface', () => {
+    NotifyMe.success('A message')
+    expect(notify.show.mock.calls.length).toEqual(1)
+    expect(notify.show.mock.calls[0]).toMatchSnapshot()
+  })
+
+  it('calls the warning toast interface', () => {
+    NotifyMe.warning('A message')
     expect(notify.show.mock.calls.length).toEqual(1)
     expect(notify.show.mock.calls[0]).toMatchSnapshot()
   })

--- a/frontend/src/utils/on-message-handler/index.js
+++ b/frontend/src/utils/on-message-handler/index.js
@@ -14,7 +14,7 @@ const playBackChanged = (store, state, progress) => {
     case MopidyApi.STOPPED:
       updatePlaybackState(store, state)
       progress.stop()
-      notify('Jukebox Halted')
+      notify.success('Jukebox Halted')
       break
     case MopidyApi.PLAYING:
       updatePlaybackState(store, state)
@@ -72,13 +72,16 @@ const onMessageHandler = (store, payload, progressTimer) => {
       break
     case MopidyApi.EVENT_VOLUME_CHANGED:
       store.dispatch(actions.updateVolume(data))
-      notify('Volume Changed')
+      notify.success('Volume Changed')
       break
     case MopidyApi.LIBRARY_GET_IMAGES:
       store.dispatch(actions.resolveImage(data))
       break
     case MopidyApi.PLAYBACK_GET_TIME_POSITION:
       progressTimer.set(data)
+      break
+    case MopidyApi.VALIDATION_ERROR:
+      notify.warning(data)
       break
     default:
       console.log(`Unknown message: ${key} body: ${data}`)

--- a/frontend/src/utils/on-message-handler/index.spec.js
+++ b/frontend/src/utils/on-message-handler/index.spec.js
@@ -284,7 +284,7 @@ describe('onMessageHandler', () => {
       onMessageHandler(store, JSON.stringify(payload), progress)
       const actions = store.getActions()
       expect(actions).toEqual([{ type: 'actionUpdateVolume', volume: 32 }])
-      expect(notify.mock.calls.length).toEqual(1)
+      expect(notify.success.mock.calls.length).toEqual(1)
     })
   })
 
@@ -323,6 +323,18 @@ describe('onMessageHandler', () => {
       onMessageHandler(store, JSON.stringify(payload), progress)
       const actions = store.getActions()
       expect(actions).toEqual([{ type: 'actionSend', key: 'mopidy::playback.getCurrentTrack' }])
+    })
+  })
+
+  describe('VALIDATION_ERROR', () => {
+    it('handles the rude', () => {
+      const payload = {
+        data: 'Is there a radio mix? - Boy - Naughty',
+        key: MopidyApi.VALIDATION_ERROR
+      }
+      const store = mockStore({})
+      onMessageHandler(store, JSON.stringify(payload), progress)
+      expect(notify.warning.mock.calls).toEqual([['Is there a radio mix? - Boy - Naughty']])
     })
   })
 })


### PR DESCRIPTION
Fixes #109 

A lot of the backend uses callbacks. This PR tries to improve things by using `Promises` where necessary. This makes the app easier to understand and more importantly, test. Ref the test bit it's allowed me to to rewrite the tests for some of the more complex areas.

The PR also makes a couple of other tweaks around validation and message handling.