### PR TITLE
Promisify transformer

### DIFF
--- a/backend/src/services/mopidy/index.js
+++ b/backend/src/services/mopidy/index.js
@@ -61,8 +61,9 @@ const MopidyService = (broadcastToAll, mopidyState, cbAllowConnections) => {
       EventLogger({ encoded_key: key }, null, message, MessageType.INCOMING_CORE)
 
       const packAndSend = (data, key, messageType) => {
-        const unifiedMessage = Transform[messageType](key, data, mopidy)
-        broadcastToAll(key, unifiedMessage)
+        Transform[messageType](key, data, mopidy).then(unifiedMessage => {
+          broadcastToAll(key, unifiedMessage)
+        })
       }
 
       if (encodedKey === MopidyConstants.CORE_EVENTS.TRACKLIST_CHANGED) {

--- a/backend/src/services/mopidy/index.spec.js
+++ b/backend/src/services/mopidy/index.spec.js
@@ -6,7 +6,12 @@ import EventLogger from 'utils/event-logger'
 import Transformer from 'utils/transformer'
 jest.mock('mopidy')
 jest.mock('utils/event-logger')
-jest.mock('utils/transformer')
+jest.mock('utils/transformer', () => {
+  return {
+    mopidyCoreMessage: jest.fn().mockImplementation(data => Promise.resolve(data)),
+    message: jest.fn().mockImplementation(data => Promise.resolve(data))
+  }
+})
 jest.mock('utils/local-storage')
 jest.mock('config/winston')
 jest.mock('services/mopidy/tracklist-trimmer')

--- a/backend/src/utils/broadcaster/index.js
+++ b/backend/src/utils/broadcaster/index.js
@@ -7,16 +7,16 @@ import Payload from 'utils/payload'
 const Broadcaster = {
   to: (client, headers, message) => {
     const key = headers.encoded_key
-    const unifiedMessage = Transform.message(key, message)
-    const context = headers.user ? MessageType.OUTGOING_API_AUTH : MessageType.OUTGOING_API
-
-    try {
-      const payload = Payload.encodeToJson(key, unifiedMessage, headers.user)
-      EventLogger(headers, null, payload, context)
-      client.emit(MessageType.GENERIC, payload)
-    } catch (e) {
-      logger.error('Broadcaster#to', { message: e.message })
-    }
+    Transform.message(key, message).then(unifiedMessage => {
+      const context = headers.user ? MessageType.OUTGOING_API_AUTH : MessageType.OUTGOING_API
+      try {
+        const payload = Payload.encodeToJson(key, unifiedMessage, headers.user)
+        EventLogger(headers, null, payload, context)
+        client.emit(MessageType.GENERIC, payload)
+      } catch (e) {
+        logger.error('Broadcaster#to', { message: e.message })
+      }
+    })
   },
 
   toAllGeneric: (socket, key, message) => {

--- a/backend/src/utils/transformer/index.js
+++ b/backend/src/utils/transformer/index.js
@@ -32,16 +32,16 @@ const Transform = {
             clearSetTimeout(recommendTimer)
             recommendTimer = setTimeout(recommend, waitToRecommend, lastTracksPlayed, mopidy)
           })
-          resolve(payload)
+          return resolve(payload)
         case Mopidy.CORE_EVENTS.VOLUME_CHANGED:
-          resolve(data.volume)
+          return resolve(data.volume)
         case Mopidy.CORE_EVENTS.PLAYBACK_STATE_CHANGED:
-          resolve(data.new_state)
+          return resolve(data.new_state)
         case Mopidy.CORE_EVENTS.TRACKLIST_CHANGED:
           clearSetTimeout(recommendTimer)
-          resolve(data)
+          return resolve(data)
         default:
-          resolve(`mopidySkippedTransform: ${key}`)
+          return resolve(`mopidySkippedTransform: ${key}`)
       }
     })
   },
@@ -49,22 +49,22 @@ const Transform = {
     return new Promise((resolve) => {
       switch (key) {
         case Mopidy.GET_CURRENT_TRACK:
-          if (!data) return resolve();
+          if (!data) return resolve()
           const trackInfo = TransformTrack(data)
           settings.setItem(Settings.TRACK_CURRENT, trackInfo.track.uri)
-          resolve(trackInfo)
+          return resolve(trackInfo)
         case Mopidy.GET_TRACKS:
           const tracks = TransformTracklist(data)
           settings.setItem(Settings.TRACKLIST_CURRENT, tracks.map(data => data.track.uri))
-          resolve(tracks)
+          return resolve(tracks)
         case Mopidy.TRACKLIST_REMOVE:
           settings.removeFromArray(Settings.TRACKLIST_LAST_PLAYED, data[0].track.uri)
-          resolve(data)
+          return resolve(data)
         case Mopidy.TRACKLIST_ADD:
         case Mopidy.PLAYBACK_NEXT:
         case Mopidy.PLAYBACK_PREVIOUS:
           clearSetTimeout(recommendTimer)
-          resolve(data)
+          return resolve(data)
         case Mopidy.TRACKLIST_CLEAR:
         case Mopidy.CONNECTION_ERROR:
         case Mopidy.LIBRARY_GET_IMAGES:
@@ -74,10 +74,11 @@ const Transform = {
         case Mopidy.PLAYBACK_GET_STATE:
         case Mopidy.VALIDATION_ERROR:
         case Auth.AUTHENTICATION_TOKEN_INVALID:
-          resolve(data)
+          return resolve(data)
         default:
-          resolve(`skippedTransform: ${key}`)
-    }})
+          return resolve(`skippedTransform: ${key}`)
+      }
+    })
   }
 }
 

--- a/backend/src/utils/transformer/index.js
+++ b/backend/src/utils/transformer/index.js
@@ -16,65 +16,68 @@ let recommendTimer
 
 const Transform = {
   mopidyCoreMessage: (key, data, mopidy) => {
-    switch (key) {
-      case Mopidy.CORE_EVENTS.PLAYBACK_STARTED:
-        const payload = TransformTrack(data.tl_track.track)
-        const { track } = payload
+    return new Promise((resolve) => {
+      switch (key) {
+        case Mopidy.CORE_EVENTS.PLAYBACK_STARTED:
+          const payload = TransformTrack(data.tl_track.track)
+          const { track } = payload
 
-        settings.addToUniqueArray(Settings.TRACKLIST_LAST_PLAYED, track.uri, 10)
-        settings.setItem(Settings.TRACK_CURRENT, track.uri)
-        NowPlaying.addTrack(track)
-        Spotify.canRecommend(mopidy, (recommend) => {
-          const waitToRecommend = track.length / 4 * 3
-          const lastTracksPlayed = settings.getItem(Settings.TRACKLIST_LAST_PLAYED) || []
+          settings.addToUniqueArray(Settings.TRACKLIST_LAST_PLAYED, track.uri, 10)
+          settings.setItem(Settings.TRACK_CURRENT, track.uri)
+          NowPlaying.addTrack(track)
+          Spotify.canRecommend(mopidy, (recommend) => {
+            const waitToRecommend = track.length / 4 * 3
+            const lastTracksPlayed = settings.getItem(Settings.TRACKLIST_LAST_PLAYED) || []
 
+            clearSetTimeout(recommendTimer)
+            recommendTimer = setTimeout(recommend, waitToRecommend, lastTracksPlayed, mopidy)
+          })
+          resolve(payload)
+        case Mopidy.CORE_EVENTS.VOLUME_CHANGED:
+          resolve(data.volume)
+        case Mopidy.CORE_EVENTS.PLAYBACK_STATE_CHANGED:
+          resolve(data.new_state)
+        case Mopidy.CORE_EVENTS.TRACKLIST_CHANGED:
           clearSetTimeout(recommendTimer)
-          recommendTimer = setTimeout(recommend, waitToRecommend, lastTracksPlayed, mopidy)
-        })
-        return payload
-      case Mopidy.CORE_EVENTS.VOLUME_CHANGED:
-        return data.volume
-      case Mopidy.CORE_EVENTS.PLAYBACK_STATE_CHANGED:
-        return data.new_state
-      case Mopidy.CORE_EVENTS.TRACKLIST_CHANGED:
-        clearSetTimeout(recommendTimer)
-        return data
-      default:
-        return `mopidySkippedTransform: ${key}`
-    }
+          resolve(data)
+        default:
+          resolve(`mopidySkippedTransform: ${key}`)
+      }
+    })
   },
   message: (key, data) => {
-    switch (key) {
-      case Mopidy.GET_CURRENT_TRACK:
-        if (!data) return null
-        const trackInfo = TransformTrack(data)
-        settings.setItem(Settings.TRACK_CURRENT, trackInfo.track.uri)
-        return trackInfo
-      case Mopidy.GET_TRACKS:
-        const tracks = TransformTracklist(data)
-        settings.setItem(Settings.TRACKLIST_CURRENT, tracks.map(data => data.track.uri))
-        return tracks
-      case Mopidy.TRACKLIST_REMOVE:
-        settings.removeFromArray(Settings.TRACKLIST_LAST_PLAYED, data[0].track.uri)
-        return data
-      case Mopidy.TRACKLIST_ADD:
-      case Mopidy.PLAYBACK_NEXT:
-      case Mopidy.PLAYBACK_PREVIOUS:
-        clearSetTimeout(recommendTimer)
-        return data
-      case Mopidy.TRACKLIST_CLEAR:
-      case Mopidy.CONNECTION_ERROR:
-      case Mopidy.LIBRARY_GET_IMAGES:
-      case Mopidy.MIXER_GET_VOLUME:
-      case Mopidy.MIXER_SET_VOLUME:
-      case Mopidy.PLAYBACK_GET_TIME_POSITION:
-      case Mopidy.PLAYBACK_GET_STATE:
-      case Mopidy.VALIDATION_ERROR:
-      case Auth.AUTHENTICATION_TOKEN_INVALID:
-        return data
-      default:
-        return `skippedTransform: ${key}`
-    }
+    return new Promise((resolve) => {
+      switch (key) {
+        case Mopidy.GET_CURRENT_TRACK:
+          if (!data) return resolve();
+          const trackInfo = TransformTrack(data)
+          settings.setItem(Settings.TRACK_CURRENT, trackInfo.track.uri)
+          resolve(trackInfo)
+        case Mopidy.GET_TRACKS:
+          const tracks = TransformTracklist(data)
+          settings.setItem(Settings.TRACKLIST_CURRENT, tracks.map(data => data.track.uri))
+          resolve(tracks)
+        case Mopidy.TRACKLIST_REMOVE:
+          settings.removeFromArray(Settings.TRACKLIST_LAST_PLAYED, data[0].track.uri)
+          resolve(data)
+        case Mopidy.TRACKLIST_ADD:
+        case Mopidy.PLAYBACK_NEXT:
+        case Mopidy.PLAYBACK_PREVIOUS:
+          clearSetTimeout(recommendTimer)
+          resolve(data)
+        case Mopidy.TRACKLIST_CLEAR:
+        case Mopidy.CONNECTION_ERROR:
+        case Mopidy.LIBRARY_GET_IMAGES:
+        case Mopidy.MIXER_GET_VOLUME:
+        case Mopidy.MIXER_SET_VOLUME:
+        case Mopidy.PLAYBACK_GET_TIME_POSITION:
+        case Mopidy.PLAYBACK_GET_STATE:
+        case Mopidy.VALIDATION_ERROR:
+        case Auth.AUTHENTICATION_TOKEN_INVALID:
+          resolve(data)
+        default:
+          resolve(`skippedTransform: ${key}`)
+    }})
   }
 }
 

--- a/backend/src/utils/transformer/index.spec.js
+++ b/backend/src/utils/transformer/index.spec.js
@@ -31,31 +31,31 @@ describe('Transformer', () => {
 
   describe('playback.getCurrentTrack', () => {
     it('transforms when we have data', () => {
-      expect.assertions(1);
+      expect.assertions(1)
       return Transformer.message('mopidy::playback.getCurrentTrack', data).then(() => expect(TransformTrack).toHaveBeenCalledWith(data))
     })
 
     it('does not transform when we have no data', () => {
-      expect.assertions(1);
+      expect.assertions(1)
       return Transformer.message('mopidy::playback.getCurrentTrack', null).then(() => expect(TransformTrack).not.toHaveBeenCalled())
     })
   })
 
   describe('playback.getTimePosition', () => {
     it('returns the data that was passed in', () => {
-      expect.assertions(1);
+      expect.assertions(1)
       return Transformer.message('mopidy::playback.getTimePosition', data).then(returnData => expect(returnData).toEqual(data))
     })
   })
 
   describe('tracklist.getTracks', () => {
     it('calls the TransformTracklist class, passes it into the settings and returns the result', () => {
-      expect.assertions(3);
+      expect.assertions(3)
       TransformTracklist.mockReturnValue([{ track: { uri: '123' } }])
       return Transformer.message('mopidy::tracklist.getTracks', data).then((returnData) => {
         expect(TransformTracklist).toHaveBeenCalledWith(data)
         expect(settings.setItem).toHaveBeenCalledWith('tracklist.current', ['123'])
-        expect(returnData).toEqual([{"track": {"uri": "123"}}])
+        expect(returnData).toEqual([{'track': {'uri': '123'}}])
       })
     })
   })
@@ -64,7 +64,7 @@ describe('Transformer', () => {
     it('transforms the track, passes to NowPlaying and sets up Spotify recommendations', () => {
       data = { tl_track: { track: 'data' } }
       const mopidyMock = jest.fn()
-      expect.assertions(5);
+      expect.assertions(5)
       return Transformer.mopidyCoreMessage('mopidy::event:trackPlaybackStarted', data, mopidyMock).then(() => {
         expect(TransformTrack).toHaveBeenCalledWith(data.tl_track.track)
         expect(NowPlaying.addTrack).toHaveBeenCalledWith({
@@ -83,7 +83,7 @@ describe('Transformer', () => {
 
   describe('event:tracklistChanged', () => {
     it('returns the data passed in', () => {
-      expect.assertions(1);
+      expect.assertions(1)
       return Transformer.mopidyCoreMessage('mopidy::event:tracklistChanged', data).then(returnData => expect(returnData).toEqual(data))
     })
   })
@@ -92,7 +92,7 @@ describe('Transformer', () => {
     data = { volume: 99 }
 
     it('returns the volume data passed in', () => {
-      expect.assertions(1);
+      expect.assertions(1)
       return Transformer.mopidyCoreMessage('mopidy::event:volumeChanged', data).then(returnData => expect(returnData).toEqual(data.volume))
     })
   })
@@ -101,21 +101,21 @@ describe('Transformer', () => {
     data = { new_state: 'playing' }
 
     it('returns the playback state data passed in', () => {
-      expect.assertions(1);
+      expect.assertions(1)
       return Transformer.mopidyCoreMessage('mopidy::event:playbackStateChanged', data).then(returnData => expect(returnData).toEqual(data.new_state))
     })
   })
 
   describe('library.getImages', () => {
     it('returns the data passed in', () => {
-      expect.assertions(1);
+      expect.assertions(1)
       return Transformer.message('mopidy::library.getImages', data).then(returnData => expect(returnData).toEqual(data))
     })
   })
 
   describe('tracklist.add', () => {
     it('returns the data passed in', () => {
-      expect.assertions(1);
+      expect.assertions(1)
       return Transformer.message('mopidy::tracklist.add', data).then(returnData => expect(returnData).toEqual(data))
     })
   })
@@ -125,53 +125,53 @@ describe('Transformer', () => {
       data = [{
         track: { uri: 'spotify:track:43xy5ZmjM9tdzmrXu1pmSG' }
       }]
-      expect.assertions(2);
+      expect.assertions(2)
       return Transformer.message('mopidy::tracklist.remove', data).then(returnData => {
         expect(returnData).toEqual(data)
         expect(settings.removeFromArray.mock.calls[0])
-        .toEqual(['tracklist.last_played', 'spotify:track:43xy5ZmjM9tdzmrXu1pmSG'])
+          .toEqual(['tracklist.last_played', 'spotify:track:43xy5ZmjM9tdzmrXu1pmSG'])
       })
     })
   })
 
   describe('tracklist.clear', () => {
     it('returns the data passed in', () => {
-      expect.assertions(1);
+      expect.assertions(1)
       return Transformer.message('mopidy::tracklist.clear', data).then(returnData => expect(returnData).toEqual(data))
     })
   })
 
   describe('mixer.getVolume', () => {
     it('returns the data passed in', () => {
-      expect.assertions(1);
+      expect.assertions(1)
       return Transformer.message('mopidy::mixer.getVolume', data).then(returnData => expect(returnData).toEqual(data))
     })
   })
 
   describe('mixer.setVolume', () => {
     it('returns the data passed in', () => {
-      expect.assertions(1);
+      expect.assertions(1)
       return Transformer.message('mopidy::mixer.setVolume', data).then(returnData => expect(returnData).toEqual(data))
     })
   })
 
   describe('playback.next', () => {
     it('returns the data passed in', () => {
-      expect.assertions(1);
+      expect.assertions(1)
       return Transformer.message('mopidy::playback.next', data).then(returnData => expect(returnData).toEqual(data))
     })
   })
 
   describe('when passing an unknown key into Transform.message', () => {
     it('returns with a skippedTransform message', () => {
-      expect.assertions(1);
+      expect.assertions(1)
       return Transformer.message('unknown', data).then(returnData => expect(returnData).toEqual('skippedTransform: unknown'))
     })
   })
 
   describe('when passing an unknown key into Transform.mopidyCoreMessage', () => {
     it('returns with a skippedTransform message', () => {
-      expect.assertions(1);
+      expect.assertions(1)
       return Transformer.mopidyCoreMessage('unknown', data).then(returnData => expect(returnData).toEqual('mopidySkippedTransform: unknown'))
     })
   })

--- a/backend/src/utils/transformer/index.spec.js
+++ b/backend/src/utils/transformer/index.spec.js
@@ -22,154 +22,157 @@ jest.mock('handlers/now-playing')
 jest.mock('./transformers/mopidy/tracklist')
 jest.useFakeTimers()
 
+let data = 'data'
+
 describe('Transformer', () => {
   afterEach(() => {
     jest.clearAllMocks()
   })
 
   describe('playback.getCurrentTrack', () => {
-    const data = 'data'
-
     it('transforms when we have data', () => {
-      Transformer.message('mopidy::playback.getCurrentTrack', data)
-      expect(TransformTrack).toHaveBeenCalledWith(data)
+      expect.assertions(1);
+      return Transformer.message('mopidy::playback.getCurrentTrack', data).then(() => expect(TransformTrack).toHaveBeenCalledWith(data))
     })
 
     it('does not transform when we have no data', () => {
-      Transformer.message('mopidy::playback.getCurrentTrack', null)
-      expect(TransformTrack).not.toHaveBeenCalled()
+      expect.assertions(1);
+      return Transformer.message('mopidy::playback.getCurrentTrack', null).then(() => expect(TransformTrack).not.toHaveBeenCalled())
     })
   })
 
   describe('playback.getTimePosition', () => {
-    const data = 'data'
-
-    it('does the right thing', () => {
-      expect(Transformer.message('mopidy::playback.getTimePosition', data)).toEqual(data)
+    it('returns the data that was passed in', () => {
+      expect.assertions(1);
+      return Transformer.message('mopidy::playback.getTimePosition', data).then(returnData => expect(returnData).toEqual(data))
     })
   })
 
   describe('tracklist.getTracks', () => {
-    const data = 'data'
-
-    it('does the right thing', () => {
+    it('calls the TransformTracklist class, passes it into the settings and returns the result', () => {
+      expect.assertions(3);
       TransformTracklist.mockReturnValue([{ track: { uri: '123' } }])
-      Transformer.message('mopidy::tracklist.getTracks', data)
-      expect(TransformTracklist).toHaveBeenCalledWith(data)
+      return Transformer.message('mopidy::tracklist.getTracks', data).then((returnData) => {
+        expect(TransformTracklist).toHaveBeenCalledWith(data)
+        expect(settings.setItem).toHaveBeenCalledWith('tracklist.current', ['123'])
+        expect(returnData).toEqual([{"track": {"uri": "123"}}])
+      })
     })
   })
 
   describe('event:trackPlaybackStarted', () => {
-    const data = { tl_track: { track: 'data' } }
-    const mopidyMock = jest.fn()
-
-    it('does the right thing', () => {
-      Transformer.mopidyCoreMessage('mopidy::event:trackPlaybackStarted', data, mopidyMock)
-      expect(TransformTrack).toHaveBeenCalledWith(data.tl_track.track)
-      expect(NowPlaying.addTrack).toHaveBeenCalledWith({
-        uri: 'spotify:track:40riOy7x9W7GXjyGp4pjAv',
-        length: 123456
+    it('transforms the track, passes to NowPlaying and sets up Spotify recommendations', () => {
+      data = { tl_track: { track: 'data' } }
+      const mopidyMock = jest.fn()
+      expect.assertions(5);
+      return Transformer.mopidyCoreMessage('mopidy::event:trackPlaybackStarted', data, mopidyMock).then(() => {
+        expect(TransformTrack).toHaveBeenCalledWith(data.tl_track.track)
+        expect(NowPlaying.addTrack).toHaveBeenCalledWith({
+          uri: 'spotify:track:40riOy7x9W7GXjyGp4pjAv',
+          length: 123456
+        })
+        expect(settings.addToUniqueArray.mock.calls[0])
+          .toEqual(['tracklist.last_played', 'spotify:track:40riOy7x9W7GXjyGp4pjAv', 10])
+        expect(Spotify.canRecommend.mock.calls[0])
+          .toEqual([mopidyMock, expect.any(Function)])
+        expect(setTimeout.mock.calls[0])
+          .toEqual(['function', 92592, [], mopidyMock])
       })
-      expect(settings.addToUniqueArray.mock.calls[0])
-        .toEqual(['tracklist.last_played', 'spotify:track:40riOy7x9W7GXjyGp4pjAv', 10])
-      expect(Spotify.canRecommend.mock.calls[0])
-        .toEqual([mopidyMock, expect.any(Function)])
-      expect(setTimeout.mock.calls[0])
-        .toEqual(['function', 92592, [], mopidyMock])
     })
   })
 
   describe('event:tracklistChanged', () => {
-    const data = 'data'
-
-    it('does the right thing', () => {
-      expect(Transformer.mopidyCoreMessage('mopidy::event:tracklistChanged', data)).toEqual(data)
+    it('returns the data passed in', () => {
+      expect.assertions(1);
+      return Transformer.mopidyCoreMessage('mopidy::event:tracklistChanged', data).then(returnData => expect(returnData).toEqual(data))
     })
   })
 
   describe('event:volumeChanged', () => {
-    const data = { volume: 99 }
+    data = { volume: 99 }
 
-    it('does the right thing', () => {
-      expect(Transformer.mopidyCoreMessage('mopidy::event:volumeChanged', data)).toEqual(data.volume)
+    it('returns the volume data passed in', () => {
+      expect.assertions(1);
+      return Transformer.mopidyCoreMessage('mopidy::event:volumeChanged', data).then(returnData => expect(returnData).toEqual(data.volume))
     })
   })
 
   describe('event:playbackStateChanged', () => {
-    const data = { new_state: 'playing' }
+    data = { new_state: 'playing' }
 
-    it('does the right thing', () => {
-      expect(Transformer.mopidyCoreMessage('mopidy::event:playbackStateChanged', data))
-        .toEqual(data.new_state)
+    it('returns the playback state data passed in', () => {
+      expect.assertions(1);
+      return Transformer.mopidyCoreMessage('mopidy::event:playbackStateChanged', data).then(returnData => expect(returnData).toEqual(data.new_state))
     })
   })
 
   describe('library.getImages', () => {
-    const data = 'data'
-
-    it('does the right thing', () => {
-      expect(Transformer.message('mopidy::library.getImages', data)).toEqual(data)
+    it('returns the data passed in', () => {
+      expect.assertions(1);
+      return Transformer.message('mopidy::library.getImages', data).then(returnData => expect(returnData).toEqual(data))
     })
   })
 
   describe('tracklist.add', () => {
-    const data = 'data'
-
-    it('does the right thing', () => {
-      expect(Transformer.message('mopidy::tracklist.add', data)).toEqual(data)
+    it('returns the data passed in', () => {
+      expect.assertions(1);
+      return Transformer.message('mopidy::tracklist.add', data).then(returnData => expect(returnData).toEqual(data))
     })
   })
 
   describe('tracklist.remove', () => {
-    const data = [{
-      track: { uri: 'spotify:track:43xy5ZmjM9tdzmrXu1pmSG' }
-    }]
-
-    it('does the right thing', () => {
-      expect(Transformer.message('mopidy::tracklist.remove', data)).toEqual(data)
-      expect(settings.removeFromArray.mock.calls[0])
+    it('removes the track from the revently played array returns the data passed in', () => {
+      data = [{
+        track: { uri: 'spotify:track:43xy5ZmjM9tdzmrXu1pmSG' }
+      }]
+      expect.assertions(2);
+      return Transformer.message('mopidy::tracklist.remove', data).then(returnData => {
+        expect(returnData).toEqual(data)
+        expect(settings.removeFromArray.mock.calls[0])
         .toEqual(['tracklist.last_played', 'spotify:track:43xy5ZmjM9tdzmrXu1pmSG'])
+      })
     })
   })
 
   describe('tracklist.clear', () => {
-    const data = 'data'
-
-    it('does the right thing', () => {
-      expect(Transformer.message('mopidy::tracklist.clear', data)).toEqual(data)
+    it('returns the data passed in', () => {
+      expect.assertions(1);
+      return Transformer.message('mopidy::tracklist.clear', data).then(returnData => expect(returnData).toEqual(data))
     })
   })
 
   describe('mixer.getVolume', () => {
-    const data = 'data'
-
-    it('does the right thing', () => {
-      expect(Transformer.message('mopidy::mixer.getVolume', data)).toEqual(data)
+    it('returns the data passed in', () => {
+      expect.assertions(1);
+      return Transformer.message('mopidy::mixer.getVolume', data).then(returnData => expect(returnData).toEqual(data))
     })
   })
 
   describe('mixer.setVolume', () => {
-    const data = 'data'
-
-    it('does the right thing', () => {
-      expect(Transformer.message('mopidy::mixer.setVolume', data)).toEqual(data)
+    it('returns the data passed in', () => {
+      expect.assertions(1);
+      return Transformer.message('mopidy::mixer.setVolume', data).then(returnData => expect(returnData).toEqual(data))
     })
   })
 
   describe('playback.next', () => {
-    const data = 'data'
-
-    it('does the right thing', () => {
-      expect(Transformer.message('mopidy::playback.next', data)).toEqual(data)
+    it('returns the data passed in', () => {
+      expect.assertions(1);
+      return Transformer.message('mopidy::playback.next', data).then(returnData => expect(returnData).toEqual(data))
     })
   })
 
-  describe('unknown', () => {
-    const data = 'data'
+  describe('when passing an unknown key into Transform.message', () => {
+    it('returns with a skippedTransform message', () => {
+      expect.assertions(1);
+      return Transformer.message('unknown', data).then(returnData => expect(returnData).toEqual('skippedTransform: unknown'))
+    })
+  })
 
-    it('does the right thing', () => {
-      expect(Transformer.message('unknown', data)).toEqual('skippedTransform: unknown')
-      expect(Transformer.mopidyCoreMessage('unknown', data)).toEqual('mopidySkippedTransform: unknown')
+  describe('when passing an unknown key into Transform.mopidyCoreMessage', () => {
+    it('returns with a skippedTransform message', () => {
+      expect.assertions(1);
+      return Transformer.mopidyCoreMessage('unknown', data).then(returnData => expect(returnData).toEqual('mopidySkippedTransform: unknown'))
     })
   })
 })


### PR DESCRIPTION
This PR rewrites the `Transformer` `message` and `mopidyCoreMessage` functions to return a promise. This should hopefully improve the control flow of these bits of code, but also will open up using asyncronous behaviour inside the flow of these messages

(This change will help the next thing I'm doing which is to include Mongo document info in the track decoration so we append user & play info)