### PR TITLE
Calculate vote average using weighting by date

### DIFF
--- a/backend/src/services/mongodb/models/track/__snapshots__/index.spec.js.snap
+++ b/backend/src/services/mongodb/models/track/__snapshots__/index.spec.js.snap
@@ -54,7 +54,7 @@ Object {
         Object {
           "at": 1970-04-06T12:00:00.000Z,
           "user": "user999",
-          "vote": 120,
+          "vote": 20,
         },
       ],
     },
@@ -62,8 +62,8 @@ Object {
   "metrics": Object {
     "plays": 0,
     "votes": 1,
-    "votesAverage": 120,
-    "votesTotal": 120,
+    "votesAverage": 20,
+    "votesTotal": 20,
   },
   "uri": "uri123",
 }

--- a/backend/src/services/mongodb/models/track/index.spec.js
+++ b/backend/src/services/mongodb/models/track/index.spec.js
@@ -232,7 +232,7 @@ describe('test mongoose Track model', () => {
       mockingoose(Track).toReturn(payload, 'findOne')
       jest.spyOn(global, 'Date').mockImplementation(() => fakeDate)
 
-      return updateTrackVote(payload._id, user, 12).then((track) => {
+      return updateTrackVote(payload._id, user, 2).then((track) => {
         expect(track).toMatchSnapshot()
       })
     })

--- a/backend/src/utils/voting/index.js
+++ b/backend/src/utils/voting/index.js
@@ -1,0 +1,51 @@
+import { flatten, mean, sumBy } from 'lodash'
+
+const VOTE_NORMALISER = 10 // asuming a vote comes in as 1-10
+const AVERAGE_WEIGHT_DISTANCE_IN_MONTHS = 6.0
+const AVERAGE_WEIGHT_DECIMALIZER = 10.0
+const MAX_SCORE = 100
+
+const VotingHelper = {
+  voteNormalised: (vote) => vote * VOTE_NORMALISER,
+
+  calcVoteCount: (data) => {
+    return sumBy(data, i => i.votes.length)
+  },
+
+  calcVoteTotal: (data) => {
+    return sumBy(data, i => sumBy(i.votes, v => v.vote))
+  },
+
+  calcVoteAverage: (data) => {
+    const votes = data.map(i => i.votes.map(j => j.vote))
+    return (votes.length > 0) ? mean(flatten(votes)) : 0
+  },
+
+  calcWeightedMean: (data) => {
+    if (data.length < 1) return 0
+    const today = (new Date()).getTime()
+    const diffInMonths = (e, s) => Math.round(Math.abs(e - s) / (2e3 * 3600 * 365.25))
+    const votes = flatten(data.map(i => i.votes.map(vote => vote)))
+    const arrWeights = votes.map(v => {
+      const diff = diffInMonths(Date.parse(v.at), today)
+      return diff / AVERAGE_WEIGHT_DISTANCE_IN_MONTHS * AVERAGE_WEIGHT_DECIMALIZER
+    })
+    const results = votes.map(v => v.vote)
+      .map((value, i) => {
+        const weight = arrWeights[i]
+        const midPoint = MAX_SCORE / 2
+
+        if (value <= midPoint) {
+          const sum = value + weight
+          return sum > midPoint ? midPoint : sum
+        } else {
+          const sum = value - weight
+          return sum < midPoint ? midPoint : sum
+        }
+      })
+
+    return Math.round(sumBy(results) / results.length)
+  }
+}
+
+export default VotingHelper

--- a/backend/src/utils/voting/index.spec.js
+++ b/backend/src/utils/voting/index.spec.js
@@ -1,0 +1,103 @@
+import VotingHelper from './index'
+
+describe('VotingHelper', () => {
+  describe('voteNormalised', () => {
+    it('should handle data', () => {
+      expect(VotingHelper.voteNormalised(2)).toEqual(20)
+    })
+  })
+
+  describe('calcVoteCount', () => {
+    it('should handle data', () => {
+      const data = [
+        { votes: [1, 2, 3, 4, 5] }
+      ]
+
+      expect(VotingHelper.calcVoteCount(data)).toEqual(5)
+    })
+
+    it('should handle no data', () => {
+      const data = []
+
+      expect(VotingHelper.calcVoteCount(data)).toEqual(0)
+    })
+  })
+
+  describe('calcVoteTotal', () => {
+    it('should handle data', () => {
+      const data = [
+        {
+          votes: [
+            { vote: 10 },
+            { vote: 20 },
+            { vote: 30 },
+            { vote: 40 }
+          ]
+        }
+      ]
+
+      expect(VotingHelper.calcVoteTotal(data)).toEqual(100)
+    })
+
+    it('should handle no data', () => {
+      const data = []
+
+      expect(VotingHelper.calcVoteTotal(data)).toEqual(0)
+    })
+  })
+
+  describe('calcVoteAverage', () => {
+    it('should handle data', () => {
+      const data = [
+        {
+          votes: [
+            { vote: 10 },
+            { vote: 20 },
+            { vote: 30 },
+            { vote: 40 }
+          ]
+        }
+      ]
+
+      expect(VotingHelper.calcVoteAverage(data)).toEqual(25)
+    })
+
+    it('should handle no data', () => {
+      const data = []
+
+      expect(VotingHelper.calcVoteAverage(data)).toEqual(0)
+    })
+  })
+
+  describe('calcWeightedMean', () => {
+    it('should handle data', () => {
+      const data = [
+        {
+          votes: [
+            { vote: 90, at: '2020-02-05T17:08:27.000Z' },
+            { vote: 80, at: '2019-08-04T17:08:27.000Z' },
+            { vote: 10, at: '2019-02-03T17:08:27.000Z' },
+            { vote: 10, at: '2018-08-02T17:08:27.000Z' }
+          ]
+        },
+        {
+          votes: [
+            { vote: 10, at: '2020-02-06T17:08:27.000Z' },
+            { vote: 10, at: '2020-02-07T17:08:27.000Z' },
+            { vote: 10, at: '2018-08-08T17:08:27.000Z' },
+            { vote: 60, at: '2018-08-08T17:08:27.000Z' },
+            { vote: 40, at: '2016-08-09T17:08:27.000Z' }
+          ]
+        }
+      ]
+
+      expect(VotingHelper.calcWeightedMean(data)).toEqual(43)
+    })
+
+    it('should handle no data', () => {
+      const data = []
+
+      expect(VotingHelper.calcWeightedMean(data)).toEqual(0)
+    })
+  })
+})

--- a/frontend/src/components/voted-by/index.js
+++ b/frontend/src/components/voted-by/index.js
@@ -4,7 +4,7 @@ import dateFormat from 'dateformat'
 import { List, Popup, Image, Label } from 'semantic-ui-react'
 import './index.css'
 
-const voteNormaliser = (v) => Math.round((v / 10) - 5) // 100 is max a user can vote per play, 0 is minimum
+const voteNormaliser = (v) => Math.round((v / 10) - 5) // 100 is max a user can vote per play
 
 const votedByContent = (votes) => (
   <List>


### PR DESCRIPTION
Currently the average vote for a track is calculated in the standard way, taking all the votes and dividing them by the count.

This change adds weighting to the calculation so the longer ago a vote is cast the less important it is to the average.

Based on todays date (2020-02-06) here's some weighted votes based on the original and the date they were voted:

```
{ vote: 90, at: '2020-02-05T17:08:27.000Z', weighted: 90 },
{ vote: 80, at: '2019-08-04T17:08:27.000Z', weighted: 70 },
{ vote: 10, at: '2019-02-03T17:08:27.000Z', weighted: 30 },
{ vote: 10, at: '2018-08-02T17:08:27.000Z', weighted: 40 }
```

Remember the scores are stored as `0-100` but are displayed as `-5` to `+5` so a score of `40 = -1`