### PR TITLE
Store now playing data as slack payload object

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,6 @@ WS_MOPIDY_URL=<Mopidy Host Name e.g mopidy.local>
 WS_MOPIDY_PORT=6680
 CLIENT_ID=<dev google client id>
 CLIENT_ID_PRODUCTION=<production google client id>
-NOW_PLAYING_URL=<(OPTIONAL) now playing add track endpoint>
 MOPIDY_USERNAME=<SPOTIFY username for Mopidy>
 MOPIDY_PASSWORD=<SPOTIFY password for Mopidy>
 MOPIDY_CLIENT_ID=<SPOTIFY client id for Mopidy>

--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ First, create a `.env` file in the root directory. Example vars can be found in 
 
 The backend also uses the Spotify API directly for some tasks. If you need this you will need to copy the `SPOTIFY_ID` and `SPOTIFY_SECRET` vars from the `.env.example` file to `.env` and [update the creds to your own](https://developer.spotify.com/dashboard/applications).
 
-In production, we are posting currently-playing track information to an endpoint defined by `NOW_PLAYING_URL`. You can optionally set this in development (e.g. to test against [kyan.rocks](https://github.com/kyan/kyan-rocks), but you can also leave it blank.
-
 ### Running the app
 
 From there, you can run everything in `Docker`. From the root of the repo, you just need to run:

--- a/backend/jukebox-api.service
+++ b/backend/jukebox-api.service
@@ -1,7 +1,10 @@
 [Unit]
 Description=Kyan Jukebox API
+Documentation=https://github.com/kyan/jukebox-js
+After=network.target
 
 [Service]
+Type=simple
 ExecStart=/usr/bin/node /home/jukebox/app/current/dist/index.js
 # Required on some systems
 #WorkingDirectory=/opt/nodeserver

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11732,6 +11732,11 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "time-ago": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/time-ago/-/time-ago-0.2.1.tgz",
+      "integrity": "sha512-fQ3WQ5yPBoNefBgITR+kMnd5aWiKYhBNSgQH3FwpJgDCaVEmju7rWyP+Rk52KyQbRwQEnw3ox2yxcS4yMxgP+g=="
+    },
     "timed-out": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "node-cron": "^2.0.3",
     "socket.io": "^2.2.0",
     "spotify-web-api-node": "^4.0.0",
+    "time-ago": "^0.2.1",
     "uuid": "^3.3.0",
     "winston": "^3.0.0"
   },

--- a/backend/src/services/mongodb/models/setting/index.js
+++ b/backend/src/services/mongodb/models/setting/index.js
@@ -5,11 +5,7 @@ const HOW_MANY_PREVIOUS_TRACKS_IN_PLAYLIST = 4
 
 const settingSchema = mongoose.Schema({
   key: mongoose.Schema.Types.String,
-  value: {
-    currentTrack: { type: mongoose.Schema.Types.String, default: null },
-    currentTracklist: { type: Array, default: [] },
-    trackSeeds: { type: Array, default: [] }
-  }
+  value: mongoose.Schema.Types.Mixed
 })
 const Setting = mongoose.model('Setting', settingSchema)
 const stateFind = { key: 'state' }

--- a/backend/src/services/mongodb/models/setting/index.spec.js
+++ b/backend/src/services/mongodb/models/setting/index.spec.js
@@ -11,7 +11,6 @@ import Setting, {
   getTracklist
 } from './index'
 jest.mock('config/winston')
-jest.mock('utils/event-logger')
 
 describe('test mongoose Settings model', () => {
   afterEach(() => {

--- a/backend/src/utils/now-playing/__snapshots__/index.spec.js.snap
+++ b/backend/src/utils/now-playing/__snapshots__/index.spec.js.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NowPlaying addTrack returns the correct payload when full data 1`] = `
+Object {
+  "blocks": Array [
+    Object {
+      "text": Object {
+        "text": "Now Playing:",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
+    Object {
+      "type": "divider",
+    },
+    Object {
+      "accessory": Object {
+        "alt_text": "Future Islands",
+        "image_url": "the-album-art.jpg",
+        "type": "image",
+      },
+      "block_id": "section1",
+      "text": Object {
+        "text": "*Seasons (Waiting On You)* 
+ Future Islands 
+ Singles (1983)",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
+    Object {
+      "type": "divider",
+    },
+    Object {
+      "block_id": "section2",
+      "fields": Array [
+        Object {
+          "text": "*Rating:* 3",
+          "type": "mrkdwn",
+        },
+        Object {
+          "text": "*Voted by:* 2 users",
+          "type": "mrkdwn",
+        },
+        Object {
+          "text": "*Played:* 2 times",
+          "type": "mrkdwn",
+        },
+        Object {
+          "text": "*Last Played:* 6 hours ago",
+          "type": "mrkdwn",
+        },
+      ],
+      "type": "section",
+    },
+    Object {
+      "elements": Array [
+        Object {
+          "text": "Added by Duncan 3 hours ago",
+          "type": "mrkdwn",
+        },
+      ],
+      "type": "context",
+    },
+  ],
+}
+`;
+
+exports[`NowPlaying addTrack returns the correct payload when full data 1 1`] = `
+Object {
+  "blocks": Array [
+    Object {
+      "text": Object {
+        "text": "Now Playing:",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
+    Object {
+      "type": "divider",
+    },
+    Object {
+      "accessory": Object {
+        "alt_text": "Future Islands",
+        "image_url": "the-album-art.jpg",
+        "type": "image",
+      },
+      "block_id": "section1",
+      "text": Object {
+        "text": "*Seasons (Waiting On You)* 
+ Future Islands 
+ Singles (1983)",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
+    Object {
+      "type": "divider",
+    },
+    Object {
+      "block_id": "section2",
+      "fields": Array [
+        Object {
+          "text": "*Rating:* 3",
+          "type": "mrkdwn",
+        },
+        Object {
+          "text": "*Voted by:* 2 users",
+          "type": "mrkdwn",
+        },
+        Object {
+          "text": "*Played:* 1 time",
+          "type": "mrkdwn",
+        },
+      ],
+      "type": "section",
+    },
+    Object {
+      "elements": Array [
+        Object {
+          "text": "Added by Duncan 3 hours ago",
+          "type": "mrkdwn",
+        },
+      ],
+      "type": "context",
+    },
+  ],
+}
+`;

--- a/backend/src/utils/now-playing/index.js
+++ b/backend/src/utils/now-playing/index.js
@@ -1,18 +1,87 @@
-import HttpService from 'services/http'
+import Setting from 'services/mongodb/models/setting'
+import logger from 'config/winston'
+import ta from 'time-ago'
+
+const slackFind = { key: 'slack' }
+const options = { upsert: true, runValidators: true, setDefaultsOnInsert: true }
+const voteNormaliser = (v) => Math.round((v / 10) - 5) // 100 is max a user can vote per play
+const simplePluralize = (count, noun, suffix = 's') => `${count} ${noun}${count !== 1 ? suffix : ''}`
+const lastPlayed = (addedBy) => {
+  return {
+    type: 'mrkdwn',
+    text: `*Last Played:* ${ta.ago(addedBy.addedAt)}`
+  }
+}
 
 const NowPlaying = {
   addTrack: (track) => {
-    if (process.env.NOW_PLAYING_URL) {
-      HttpService.post({
-        url: `${process.env.NOW_PLAYING_URL}`,
-        data: {
-          title: track.name,
-          artist: track.artist.name,
-          album: track.album.name,
-          added_by: 'Jukebox JS'
+    return new Promise((resolve) => {
+      const metrics = [
+        {
+          type: 'mrkdwn',
+          text: `*Rating:* ${voteNormaliser(track.metrics.votesAverage)}`
+        },
+        {
+          type: 'mrkdwn',
+          text: `*Voted by:* ${simplePluralize(track.metrics.votes, 'user')}`
+        },
+        {
+          type: 'mrkdwn',
+          text: `*Played:* ${simplePluralize(track.metrics.plays, 'time')}`
         }
-      })
-    }
+      ]
+      if (track.addedBy[1]) metrics.push(lastPlayed(track.addedBy[1]))
+
+      const payload = {
+        blocks: [
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: 'Now Playing:'
+            }
+          },
+          {
+            type: 'divider'
+          },
+          {
+            type: 'section',
+            block_id: 'section1',
+            text: {
+              type: 'mrkdwn',
+              text: `*${track.name}* \n ${track.artist.name} \n ${track.album.name} (${track.year})`
+            },
+            accessory: {
+              type: 'image',
+              image_url: track.image,
+              alt_text: track.artist.name
+            }
+          },
+          {
+            type: 'divider'
+          },
+          {
+            type: 'section',
+            block_id: 'section2',
+            fields: metrics
+          },
+          {
+            type: 'context',
+            elements: [
+              {
+                type: 'mrkdwn',
+                text: `Added by ${track.addedBy[0].user.fullname} ${ta.ago(track.addedBy[0].addedAt)}`
+              }
+            ]
+          }
+        ]
+      }
+
+      const updateValue = { $set: { 'value.currentTrack': payload } }
+      return Setting.findOneAndUpdate(slackFind, updateValue, options)
+        .then(() => resolve(payload))
+        .catch((error) => logger.error(`NowPlaying.addTrack: ${error.message}`))
+    })
   }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,6 @@ services:
       - SPOTIFY_SECRET=${SPOTIFY_SECRET}
       - SPOTIFY_NEW_TRACKS_ADDED_LIMIT=3
       - CLIENT_ID=${CLIENT_ID}
-      - NOW_PLAYING_URL=${NOW_PLAYING_URL}
   mongodb:
     image: mongo:4.2-bionic
     container_name: mongodb

--- a/frontend/src/utils/on-message-handler/index.js
+++ b/frontend/src/utils/on-message-handler/index.js
@@ -44,7 +44,7 @@ const onMessageHandler = (store, payload, progressTimer) => {
 
   switch (key) {
     case AuthApi.AUTHENTICATION_TOKEN_INVALID:
-      console.log(`AUTHENTICATION_TOKEN_INVALID: ${data.error}`)
+      console.error(`AUTHENTICATION_TOKEN_INVALID: ${data.error}`)
       store.dispatch(actions.clearToken())
       break
     case MopidyApi.PLAYBACK_GET_CURRENT_TRACK:
@@ -88,7 +88,6 @@ const onMessageHandler = (store, payload, progressTimer) => {
       notify.warning(data)
       break
     default:
-      console.log(`Unknown message: ${key} body: ${data}`)
       break
   }
 }

--- a/frontend/src/utils/on-message-handler/index.spec.js
+++ b/frontend/src/utils/on-message-handler/index.spec.js
@@ -22,7 +22,7 @@ describe('onMessageHandler', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    spyOn(console, 'log')
+    spyOn(console, 'error')
   })
 
   describe('MESSAGE_NOT_HANDLED', () => {
@@ -30,7 +30,6 @@ describe('onMessageHandler', () => {
       const payload = { key: 'message_not_handled' }
       const store = mockStore({})
       onMessageHandler(store, JSON.stringify(payload), progress)
-      expect(console.log).toHaveBeenCalled()
     })
   })
 
@@ -261,7 +260,7 @@ describe('onMessageHandler', () => {
       onMessageHandler(store, JSON.stringify(payload), progress)
       const actions = store.getActions()
       expect(actions).toEqual([{ type: 'actionClearStoreToken' }])
-      expect(console.log).toHaveBeenCalledWith('AUTHENTICATION_TOKEN_INVALID: boom')
+      expect(console.error).toHaveBeenCalledWith('AUTHENTICATION_TOKEN_INVALID: boom')
       store.clearActions()
     })
   })


### PR DESCRIPTION
Fixes #141

Replaces the sending of Now playing data to another service to storing now playing data in a format that can be reused.