### PR TITLE
Fix issue where album art sometimes didn't get added

### DIFF
--- a/backend/src/decorators/mopidy/tracklist/index.js
+++ b/backend/src/decorators/mopidy/tracklist/index.js
@@ -2,13 +2,12 @@ import DecorateTrack from 'decorators/mopidy/track'
 import { findTracks } from 'services/mongodb/models/track'
 import ImageCache from 'utils/image-cache'
 
-const DecorateTracklist = (json) => {
-  return new Promise((resolve) => {
-    const trackUris = json.map(data => data.uri)
-    const imageUris = json.filter(data => data.album).map(data => data.album.uri)
+const DecorateTracklist = (json) => (
+  new Promise((resolve) => {
+    const uris = json.map(data => data.uri)
     const requests = [
-      findTracks(trackUris),
-      ImageCache.findAll(imageUris)
+      findTracks(uris),
+      ImageCache.findAll(uris)
     ]
 
     Promise.all(requests).then((responses) => {
@@ -16,7 +15,7 @@ const DecorateTracklist = (json) => {
       const images = responses[1]
       const decoratedTracks = json.map(data => {
         const trackData = tracks.find(track => track._id === data.uri)
-        const imageData = images.find(image => image._id === (data.album && data.album.uri))
+        const imageData = images.find(image => image._id === data.uri)
 
         if (trackData) {
           data.addedBy = trackData.addedBy
@@ -30,6 +29,6 @@ const DecorateTracklist = (json) => {
       return resolve(decoratedTracks)
     })
   })
-}
+)
 
 export default DecorateTracklist

--- a/backend/src/decorators/mopidy/tracklist/index.spec.js
+++ b/backend/src/decorators/mopidy/tracklist/index.spec.js
@@ -29,7 +29,7 @@ const secondTrack = {
   __v: 0
 }
 const firstImage = {
-  _id: 'spotify:album:13gokJcmO1Dbc9cbHM93jO',
+  _id: 'spotify:track:6IZWJhXyk1Z0rtWNxIi4o7',
   url: 'path/to/image/1'
 }
 const mockTrackData = [firstTrack, secondTrack]

--- a/backend/src/services/mongodb/models/track/index.js
+++ b/backend/src/services/mongodb/models/track/index.js
@@ -37,18 +37,18 @@ const brh = {
   picture: 'https://cdn-images-1.medium.com/fit/c/200/200/1*bFBXYvskkPFI9nPx6Elwxg.png'
 }
 
-const findTracks = (uris) => {
-  return new Promise((resolve, reject) => {
+const findTracks = (uris) => (
+  new Promise((resolve, reject) => {
     Track.find({ _id: { $in: uris } })
       .populate({ path: 'addedBy.user' })
       .populate({ path: 'addedBy.votes.user' })
       .then(tracks => {
         if (tracks.length > 0) EventLogger.info('FOUND CACHED TRACKS', { data: uris })
-        return resolve(tracks)
+        resolve(tracks)
       })
       .catch(err => reject(err))
   })
-}
+)
 
 const findOrUseBRH = (user) => {
   if (user) return Promise.resolve(user)
@@ -60,8 +60,8 @@ const findOrUseBRH = (user) => {
   )
 }
 
-const addTracks = (uris, user) => {
-  return new Promise((resolve) => {
+const addTracks = (uris, user) => (
+  new Promise((resolve) => {
     findOrUseBRH(user).then((returnUser) => {
       const requests = uris.map((uri) => (
         Track.findOneAndUpdate(
@@ -76,10 +76,10 @@ const addTracks = (uris, user) => {
         .catch((error) => logger.error('addTracks:Track.updateOne', { message: error.message }))
     }).catch((error) => logger.error('addTracks:findOrUseBRH', { message: error.message }))
   })
-}
+)
 
-const updateTrackPlaycount = (uri) => {
-  return new Promise((resolve) => {
+const updateTrackPlaycount = (uri) => (
+  new Promise((resolve) => {
     Track.findById(uri)
       .populate({ path: 'addedBy.user' })
       .populate({ path: 'addedBy.votes.user' })
@@ -95,10 +95,10 @@ const updateTrackPlaycount = (uri) => {
       .then((track) => resolve(track))
       .catch((error) => logger.error('updateTrackPlaycount', { message: error.message }))
   })
-}
+)
 
-const updateTrackVote = (uri, user, vote) => {
-  return new Promise((resolve) => {
+const updateTrackVote = (uri, user, vote) => (
+  new Promise((resolve) => {
     findOrUseBRH(user).then((returnUser) => {
       Track.findById(uri)
         .populate({ path: 'addedBy.user' })
@@ -128,7 +128,7 @@ const updateTrackVote = (uri, user, vote) => {
         .catch((error) => logger.error('updateTrackVote:findById', { message: error.message }))
     }).catch((error) => logger.error('updateTrackVote:findOrUseBRH', { message: error.message }))
   })
-}
+)
 
 export default Track
 export { findTracks, addTracks, updateTrackPlaycount, updateTrackVote }

--- a/backend/src/utils/recommendations/index.js
+++ b/backend/src/utils/recommendations/index.js
@@ -7,12 +7,12 @@ const newTracksAddedLimit = process.env.SPOTIFY_NEW_TRACKS_ADDED_LIMIT
 const Recommendations = {
   getImageFromSpotifyTracks: (tracks) => {
     const albumTracks = tracks.filter((track) => track.album)
-    const images = albumTracks.map(track => ({ [track.album.uri]: track.album.images[0].url }))
+    const images = albumTracks.map(track => ({ [track.uri]: track.album.images[0].url }))
     return Object.assign({}, ...images)
   },
 
-  extractSuitableData: (tracks) => {
-    return new Promise((resolve) => {
+  extractSuitableData: (tracks) => (
+    new Promise((resolve) => {
       getTracklist()
         .then(currentTrackListUris => {
           const images = Recommendations.getImageFromSpotifyTracks(tracks)
@@ -37,7 +37,7 @@ const Recommendations = {
           })
         })
     })
-  },
+  ),
 
   addRandomUris: (data) => {
     if (data.uris.length > 0) return Promise.resolve(data)

--- a/backend/src/utils/recommendations/index.spec.js
+++ b/backend/src/utils/recommendations/index.spec.js
@@ -20,7 +20,7 @@ describe('Recommend', () => {
         { uri: 'track1', album: { uri: 'uri1', images: [{ url: 'image1' }] } },
         { uri: 'track2', album: { uri: 'uri2', images: [{ url: 'image2' }] } }
       ]
-      expect(Recommend.getImageFromSpotifyTracks(tracks)).toEqual({ uri1: 'image1', uri2: 'image2' })
+      expect(Recommend.getImageFromSpotifyTracks(tracks)).toEqual({ track1: 'image1', track2: 'image2' })
     })
   })
 
@@ -40,9 +40,9 @@ describe('Recommend', () => {
       return Recommend.extractSuitableData(tracks).then((data) => {
         expect(data).toEqual({
           images: {
-            uri1: 'image1',
-            uri2: 'image2',
-            uri3: 'image3'
+            track1: 'image1',
+            track2: 'image2',
+            track3: 'image3'
           },
           uris: ['track2']
         })


### PR DESCRIPTION
Fixes an issue where sometimes it would look like album art was not added and the album would have a default image.

This was actually not the case and the art was indeed being added. The issue was that some tracks appear on multiple albums and we use the `album` uri as the key to store the art against. The app was choosing the first album, but it turns out that that list comes back in a different order from both the API Mopidy uses and the web API the app uses so the first sometime doesn't match ! Anyway, it has been resolved by storing the album art against the `track` uri now. 