### PR TITLE
Don't download playlists as it's expensive

### DIFF
--- a/mopidy/config/mopidy.conf
+++ b/mopidy/config/mopidy.conf
@@ -35,6 +35,7 @@ password = %MOPIDY_PASSWORD%
 client_id = %MOPIDY_CLIENT_ID%
 client_secret = %MOPIDY_CLIENT_SECRET%
 private_session = true
+allow_playlists = false
 
 [mpd]
 enabled = true


### PR DESCRIPTION
Turns out that mopidy will attempt to download all your playlists by default and it's takes some time if you have a lot. We're not using that functionality so let's disable it.
