### PR TITLE
Some auto suggest improvements

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -46,3 +46,4 @@ jobs:
         WS_MOPIDY_PORT: 6680
         CLIENT_ID: abcdefg
         EXPLICIT_CONTENT: true
+        SPOTIFY_NEW_TRACKS_ADDED_LIMIT: 3

--- a/backend/src/services/mongodb/models/setting/index.js
+++ b/backend/src/services/mongodb/models/setting/index.js
@@ -12,8 +12,8 @@ const stateFind = { key: 'state' }
 const options = { upsert: true, runValidators: true, setDefaultsOnInsert: true }
 
 const addToTrackSeedList = (track) => {
-  if (track.metrics && track.metrics.votesAverage < 20) return Promise.resolve()
-  if (track.metrics && track.metrics.votes < 1) return Promise.resolve()
+  if (track.metrics && track.metrics.votes > 1 && track.metrics.votesAverage < 50) return Promise.resolve()
+  if (track.metrics && track.metrics.plays > 2 && track.metrics.votes < 1) return Promise.resolve()
 
   return new Promise((resolve) => {
     return Setting.findOne(stateFind)

--- a/backend/src/services/mongodb/models/setting/index.spec.js
+++ b/backend/src/services/mongodb/models/setting/index.spec.js
@@ -122,7 +122,8 @@ describe('test mongoose Settings model', () => {
         uri: 'uri123',
         metrics: {
           votesAverage: 50,
-          votes: 10
+          votes: 10,
+          plays: 10
         }
       }
 
@@ -132,13 +133,14 @@ describe('test mongoose Settings model', () => {
       })
     })
 
-    it('returns when average < 20', () => {
+    it('returns when average < 0', () => {
       expect.assertions(1)
       const track = {
         uri: 'uri123',
         metrics: {
           votesAverage: 10,
-          votes: 10
+          votes: 10,
+          plays: 10
         }
       }
 
@@ -153,7 +155,8 @@ describe('test mongoose Settings model', () => {
         uri: 'uri123',
         metrics: {
           votesAverage: 50,
-          votes: 0
+          votes: 0,
+          plays: 10
         }
       }
 

--- a/backend/src/services/spotify/index.js
+++ b/backend/src/services/spotify/index.js
@@ -48,7 +48,7 @@ const searchTracks = (params) => {
   })
 }
 
-const getTracks = (uris) => {
+const getSpotifyTracks = (uris) => {
   return new Promise((resolve) => {
     const trackUris = stripServiceFromUris(uris)
 
@@ -70,10 +70,12 @@ const getRecommendations = (uris, mopidy) => {
   return new Promise((resolve, reject) => {
     const seedTracks = stripServiceFromUris(uris.slice(-5))
     const seedOptions = {
-      min_popularity: 20,
       seed_tracks: seedTracks,
-      valence: 0.7,
-      liveness: 0.0
+      min_popularity: 30,
+      min_valence: 0.5,
+      max_liveness: 0.2,
+      max_duration_ms: 480000,
+      max_speechiness: 0.4
     }
     const options = { ...defaultOptions, ...seedOptions }
 
@@ -156,7 +158,7 @@ const SpotifyService = {
   },
 
   search: params => searchTracks(params),
-  getTracks: uris => getTracks(uris)
+  getTracks: uris => getSpotifyTracks(uris)
 }
 
 export default SpotifyService


### PR DESCRIPTION
A couple of tweaks to the BRH auto suggest logic to see if we can continue to improve things.

* Don't add to seeds for suggestion request if track voted on and the average vote is negative
* Don't add to seeds for suggestion request if track played more than twice but never voted on
* tweak suggest API params:
```
min_popularity: 30,
min_valence: 0.5,
max_liveness: 0.2,
max_duration_ms: 480000,
max_speechiness: 0.4
```
* Update rules of what happens with any suggestions that get returned from Spotify
```
# filter out explicit tracks
# filter out tracks in the current playlist
# filter out tracks that have been played before but have a negative vote
# sort by Spotify popularity figure
# limit to 3
```

