### PR TITLE
JSON data

### DIFF
--- a/backend/src/utils/now-playing.ts
+++ b/backend/src/utils/now-playing.ts
@@ -29,7 +29,7 @@ const NowPlaying = {
         metrics: {
           rating: voteNormaliser(track.metrics.votesAverage),
           votes: track.metrics.votes,
-          played: track.metrics.plays
+          plays: track.metrics.plays
         },
         added_by: track.addedBy[0].user.fullname,
         added_at: timeAgo.format(track.addedBy[0].addedAt),

--- a/backend/src/utils/now-playing.ts
+++ b/backend/src/utils/now-playing.ts
@@ -1,90 +1,39 @@
 import Setting from '../models/setting'
-import { JBTrack, JBAddedBy } from '../models/track'
+import { JBTrack } from '../models/track'
 import logger from '../config/logger'
 import TimeAgo from 'javascript-time-ago'
 import en from 'javascript-time-ago/locale/en'
 
 TimeAgo.addLocale(en)
 
-const slackFind = { key: 'slack' }
+// This is the Settings key where we store any JSON
+const slackFind = { key: 'json' }
 const options = { upsert: true, runValidators: true, setDefaultsOnInsert: true }
-const voteNormaliser = (v: number) => Math.round(v / 10 - 5) // 100 is max a user can vote per play
-const simplePluralize = (count: number, noun: string, suffix = 's') => {
-  return `${count} ${noun}${count !== 1 ? suffix : ''}`
-}
 const timeAgo = new TimeAgo('en-GB')
-const lastPlayed = (addedBy: JBAddedBy) => {
-  return {
-    type: 'mrkdwn',
-    text: `*Last Played:* ${timeAgo.format(addedBy.addedAt)}`
-  }
+const voteNormaliser = (v: number) => Math.round(v / 10 - 5) // 100 is max a user can vote per play
+const spotifyLink = (uri: string) => {
+  const code = uri.split(':').pop()
+  return `https://open.spotify.com/track/${code}`
 }
 
 const NowPlaying = {
   addTrack: (track: JBTrack): Promise<unknown> => {
     return new Promise((resolve) => {
-      const metrics = [
-        {
-          type: 'mrkdwn',
-          text: `*Rating:* ${voteNormaliser(track.metrics.votesAverage)}`
-        },
-        {
-          type: 'mrkdwn',
-          text: `*Voted by:* ${simplePluralize(track.metrics.votes, 'user')}`
-        },
-        {
-          type: 'mrkdwn',
-          text: `*Played:* ${simplePluralize(track.metrics.plays, 'time')}`
-        }
-      ]
-
-      if (track.addedBy[1]) metrics.push(lastPlayed(track.addedBy[1]))
-
       const payload: unknown = {
-        blocks: [
-          {
-            type: 'section',
-            text: {
-              type: 'mrkdwn',
-              text: 'Now Playing:'
-            }
-          },
-          {
-            type: 'divider'
-          },
-          {
-            type: 'section',
-            block_id: 'section1',
-            text: {
-              type: 'mrkdwn',
-              text: `*${track.name}* \n ${track.artist.name} \n ${track.album.name} (${track.year})`
-            },
-            accessory: {
-              type: 'image',
-              image_url: track.image,
-              alt_text: track.artist.name
-            }
-          },
-          {
-            type: 'divider'
-          },
-          {
-            type: 'section',
-            block_id: 'section2',
-            fields: metrics
-          },
-          {
-            type: 'context',
-            elements: [
-              {
-                type: 'mrkdwn',
-                text: `Added by ${track.addedBy[0].user.fullname} ${timeAgo.format(
-                  track.addedBy[0].addedAt
-                )}`
-              }
-            ]
-          }
-        ]
+        spotify: spotifyLink(track.uri),
+        title: track.name,
+        artist: track.artist.name,
+        album: track.album.name,
+        year: track.year,
+        image: track.image,
+        metrics: {
+          rating: voteNormaliser(track.metrics.votesAverage),
+          votes: track.metrics.votes,
+          played: track.metrics.plays
+        },
+        added_by: track.addedBy[0].user.fullname,
+        added_at: timeAgo.format(track.addedBy[0].addedAt),
+        last_played: track.addedBy[1] ? timeAgo.format(track.addedBy[1].addedAt) : null
       }
 
       const updateValue = { $set: { 'value.currentTrack': payload } }

--- a/backend/test/utils/__snapshots__/now-playing.test.ts.snap
+++ b/backend/test/utils/__snapshots__/now-playing.test.ts.snap
@@ -9,7 +9,7 @@ Object {
   "image": "the-album-art.jpg",
   "last_played": "6 hours ago",
   "metrics": Object {
-    "played": 2,
+    "plays": 2,
     "rating": 3,
     "votes": 2,
   },
@@ -28,7 +28,7 @@ Object {
   "image": "the-album-art.jpg",
   "last_played": null,
   "metrics": Object {
-    "played": 1,
+    "plays": 1,
     "rating": 3,
     "votes": 2,
   },

--- a/backend/test/utils/__snapshots__/now-playing.test.ts.snap
+++ b/backend/test/utils/__snapshots__/now-playing.test.ts.snap
@@ -2,128 +2,38 @@
 
 exports[`NowPlaying addTrack returns the correct payload when full data 1`] = `
 Object {
-  "blocks": Array [
-    Object {
-      "text": Object {
-        "text": "Now Playing:",
-        "type": "mrkdwn",
-      },
-      "type": "section",
-    },
-    Object {
-      "type": "divider",
-    },
-    Object {
-      "accessory": Object {
-        "alt_text": "Future Islands",
-        "image_url": "the-album-art.jpg",
-        "type": "image",
-      },
-      "block_id": "section1",
-      "text": Object {
-        "text": "*Seasons (Waiting On You)* 
- Future Islands 
- Singles (1983)",
-        "type": "mrkdwn",
-      },
-      "type": "section",
-    },
-    Object {
-      "type": "divider",
-    },
-    Object {
-      "block_id": "section2",
-      "fields": Array [
-        Object {
-          "text": "*Rating:* 3",
-          "type": "mrkdwn",
-        },
-        Object {
-          "text": "*Voted by:* 2 users",
-          "type": "mrkdwn",
-        },
-        Object {
-          "text": "*Played:* 2 times",
-          "type": "mrkdwn",
-        },
-        Object {
-          "text": "*Last Played:* 6 hours ago",
-          "type": "mrkdwn",
-        },
-      ],
-      "type": "section",
-    },
-    Object {
-      "elements": Array [
-        Object {
-          "text": "Added by Duncan 3 hours ago",
-          "type": "mrkdwn",
-        },
-      ],
-      "type": "context",
-    },
-  ],
+  "added_at": "3 hours ago",
+  "added_by": "Duncan",
+  "album": "Singles",
+  "artist": "Future Islands",
+  "image": "the-album-art.jpg",
+  "last_played": "6 hours ago",
+  "metrics": Object {
+    "played": 2,
+    "rating": 3,
+    "votes": 2,
+  },
+  "spotify": "https://open.spotify.com/track/uri000",
+  "title": "Seasons (Waiting On You)",
+  "year": "1983",
 }
 `;
 
-exports[`NowPlaying addTrack returns the correct payload when full data 1 1`] = `
+exports[`NowPlaying addTrack returns the correct payload when partial full data 1`] = `
 Object {
-  "blocks": Array [
-    Object {
-      "text": Object {
-        "text": "Now Playing:",
-        "type": "mrkdwn",
-      },
-      "type": "section",
-    },
-    Object {
-      "type": "divider",
-    },
-    Object {
-      "accessory": Object {
-        "alt_text": "Future Islands",
-        "image_url": "the-album-art.jpg",
-        "type": "image",
-      },
-      "block_id": "section1",
-      "text": Object {
-        "text": "*Seasons (Waiting On You)* 
- Future Islands 
- Singles (1983)",
-        "type": "mrkdwn",
-      },
-      "type": "section",
-    },
-    Object {
-      "type": "divider",
-    },
-    Object {
-      "block_id": "section2",
-      "fields": Array [
-        Object {
-          "text": "*Rating:* 3",
-          "type": "mrkdwn",
-        },
-        Object {
-          "text": "*Voted by:* 2 users",
-          "type": "mrkdwn",
-        },
-        Object {
-          "text": "*Played:* 1 time",
-          "type": "mrkdwn",
-        },
-      ],
-      "type": "section",
-    },
-    Object {
-      "elements": Array [
-        Object {
-          "text": "Added by Duncan 3 hours ago",
-          "type": "mrkdwn",
-        },
-      ],
-      "type": "context",
-    },
-  ],
+  "added_at": "3 hours ago",
+  "added_by": "Duncan",
+  "album": "Singles",
+  "artist": "Future Islands",
+  "image": "the-album-art.jpg",
+  "last_played": null,
+  "metrics": Object {
+    "played": 1,
+    "rating": 3,
+    "votes": 2,
+  },
+  "spotify": "https://open.spotify.com/track/uri000",
+  "title": "Seasons (Waiting On You)",
+  "year": "1983",
 }
 `;

--- a/backend/test/utils/now-playing.test.ts
+++ b/backend/test/utils/now-playing.test.ts
@@ -49,10 +49,15 @@ describe('NowPlaying', () => {
 
       return NowPlaying.addTrack(trackObject).then((payload) => {
         expect(payload).toMatchSnapshot()
+        expect(Setting.findOneAndUpdate).toHaveBeenCalledWith(
+          { key: 'json' },
+          { $set: { 'value.currentTrack': payload } },
+          { runValidators: true, setDefaultsOnInsert: true, upsert: true }
+        )
       })
     })
 
-    it('returns the correct payload when full data 1', () => {
+    it('returns the correct payload when partial full data', () => {
       const result = {} as any
       jest.spyOn(Setting, 'findOneAndUpdate').mockResolvedValue(result)
       jest.spyOn(global.Date, 'now').mockImplementation(() => 1582020703141)
@@ -61,6 +66,11 @@ describe('NowPlaying', () => {
 
       return NowPlaying.addTrack(trackObject).then((payload) => {
         expect(payload).toMatchSnapshot()
+        expect(Setting.findOneAndUpdate).toHaveBeenCalledWith(
+          { key: 'json' },
+          { $set: { 'value.currentTrack': payload } },
+          { runValidators: true, setDefaultsOnInsert: true, upsert: true }
+        )
       })
     })
 


### PR DESCRIPTION
We currently save the current playing track data in the Slack message format. This is because initially this was the only thing that used it. Now though we also use it in our desktop app. Rather than have to unpick it for another render we should store this information in a generic JSON format and then any service can read and use it.


```json
{
  "spotify": "https://open.spotify.com/track/uri000", 
  "title": "Seasons (Waiting On You)",
  "album": "Singles",
  "artist": "Future Islands",
  "year": "1983",
  "image": "the-album-art.jpg",
  "last_played": "6 hours ago",
  "metrics": {
    "played": 2,
    "rating": 3,
    "votes": 2
  },
  "added_at": "3 hours ago",
  "added_by": "Duncan"
}